### PR TITLE
Update to vulkan 1.58 xml

### DIFF
--- a/src/vk.generator/EnumHelpers.cs
+++ b/src/vk.generator/EnumHelpers.cs
@@ -17,6 +17,19 @@ namespace Vk.Generator
         private static readonly Dictionary<string, string> s_knownEnumValueNames = new Dictionary<string, string>
         {
             {  "VK_STENCIL_FRONT_AND_BACK", "FrontAndBack" },
+            // VkStructureType
+            {  "VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES2_EXT", "SurfaceCapabilities2Ext" },
+            {  "VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR", "SurfaceCapabilities2Khr" },
+            {  "VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_KHR", "ExportMemoryImageCreateInfoKHR" },
+            {  "VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV", "ExportMemoryImageCreateInfoNV" },
+            {  "VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV", "Win32KeyedMutexAcquireReleaseInfoNV" },
+            {  "VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_NV", "ExportMemoryAllocateInfoNV" },
+            {  "VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR", "ExportMemoryAllocateInfoKHR" },
+            {  "VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_NV", "ImportMemoryWin32HandleInfoNV" },
+            {  "VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR", "ImportMemoryWin32HandleInfoKHR" },
+            {  "VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_NV", "ExportMemoryWin32HandleInfoNV" },
+            {  "VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR", "ExportMemoryWin32HandleInfoKHR" },
+
             // VkSampleCountFlagBits
             {  "VK_SAMPLE_COUNT_1_BIT", "Count1" },
             {  "VK_SAMPLE_COUNT_2_BIT", "Count2" },

--- a/src/vk.generator/ExtensionDefinition.cs
+++ b/src/vk.generator/ExtensionDefinition.cs
@@ -76,7 +76,11 @@ namespace Vk.Generator
                 }
                 else
                 {
-                    extensionConstants.Add(new ExtensionConstant(name, enumXE.Attribute("value").Value));
+                    var valueAttribute = enumXE.Attribute("value");
+                    if (valueAttribute == null)
+                        continue;
+
+                    extensionConstants.Add(new ExtensionConstant(name, valueAttribute.Value));
                 }
             }
             foreach (var commandXE in require.Elements("command"))

--- a/src/vk.generator/StructureHelpers.cs
+++ b/src/vk.generator/StructureHelpers.cs
@@ -26,7 +26,11 @@ namespace Vk.Generator
                     }
                     else if (member.ElementCountSymbolic != null)
                     {
-                        WriteMemberSymbolicCount(cw, tnm, member, constants);
+                        var validConstant = constants.FirstOrDefault(cd => cd.Name == member.ElementCountSymbolic);
+                        if (validConstant != null)
+                            WriteMemberSymbolicCount(cw, tnm, member, constants);
+                        else
+                            WriteMember(cw, tnm, member, string.Empty);
                     }
                     else
                     {

--- a/src/vk.generator/TypeNameMappings.cs
+++ b/src/vk.generator/TypeNameMappings.cs
@@ -28,11 +28,13 @@ namespace Vk.Generator
             { "Display", "Xlib.Display" },
             { "Window", "Xlib.Window" },
             { "VisualID", "Xlib.VisualID" },
+            { "RROutput", "IntPtr" },
 
             { "HINSTANCE", "Win32.HINSTANCE" },
             { "HWND", "Win32.HWND" },
             { "HANDLE", "Win32.HANDLE" },
             { "SECURITY_ATTRIBUTES", "Win32.SECURITY_ATTRIBUTES" },
+            { "LPCWSTR", "IntPtr" },
 
             { "xcb_connection_t", "Xcb.xcb_connection_t" },
             { "xcb_window_t", "Xcb.xcb_window_t" },

--- a/src/vk.generator/vk.xml
+++ b/src/vk.generator/vk.xml
@@ -1,26 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <registry>
     <comment>
-Copyright (c) 2015-2016 The Khronos Group Inc.
+Copyright (c) 2015-2017 The Khronos Group Inc.
 
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and/or associated documentation files (the
-"Materials"), to deal in the Materials without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Materials, and to
-permit persons to whom the Materials are furnished to do so, subject to
-the following conditions:
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Materials.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 ------------------------------------------------------------------------
 
@@ -29,21 +22,21 @@ and normative part of the Vulkan Specification, including a canonical
 machine-readable definition of the API, parameter and member validation
 language incorporated into the Specification and reference pages, and other
 material which is registered by Khronos, such as tags used by extension and
-layer authors. The only authoritative version of vk.xml is the one
-maintained in the master branch of the Khronos Vulkan GitHub project.
+layer authors. The authoritative public version of vk.xml is maintained in
+the master branch of the Khronos Vulkan GitHub project. The authoritative
+private version is maintained in the 1.0 branch of the member gitlab server.
     </comment>
 
-    <!-- SECTION: Vulkan vendor IDs for physical devices without PCI vendor IDs -->
-    <vendorids>
+    <vendorids comment="Vulkan vendor IDs for physical devices without PCI vendor IDs">
         <vendorid name="KHR"    id="0x10000"            comment="This is the next available Khronos vendor ID"/>
         <vendorid name="VIV"    id="0x10001"            comment="Vivante vendor ID"/>
         <vendorid name="VSI"    id="0x10002"            comment="VeriSilicon vendor ID"/>
     </vendorids>
 
-    <!-- SECTION: Vulkan vendor/author tags for extensions and layers -->
-    <tags>
+    <tags comment="Vulkan vendor/author tags for extensions and layers">
         <tag name="IMG"         author="Imagination Technologies"      contact="Michael Worcester @michaelworcester"/>
         <tag name="AMD"         author="Advanced Micro Devices, Inc."  contact="Daniel Rakos @aqnuep"/>
+        <tag name="AMDX"        author="Advanced Micro Devices, Inc."  contact="Daniel Rakos @aqnuep"/>
         <tag name="ARM"         author="ARM Limited"                   contact="Jan-Harald Fredriksen @janharald"/>
         <tag name="FSL"         author="Freescale Semiconductor, Inc." contact="Norbert Nopper @FslNopper"/>
         <tag name="BRCM"        author="Broadcom Corporation"          contact="Graeme Leese @gnl21"/>
@@ -62,14 +55,21 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <tag name="SEC"         author="Samsung Electronics Co., Ltd." contact="Alon Or-bach @alonorbach"/>
         <tag name="TIZEN"       author="Samsung Electronics Co., Ltd." contact="Alon Or-bach @alonorbach"/>
         <tag name="RENDERDOC"   author="RenderDoc (renderdoc.org)"     contact="baldurk@baldurk.org"/>
+        <tag name="NN"          author="Nintendo Co., Ltd."            contact="Yasuhiro Yoshioka @yoshioka_yasuhiro"/>
+        <tag name="MVK"         author="The Brenwill Workshop Ltd."    contact="Bill Hollings @billhollings"/>
+        <tag name="KHR"         author="Khronos"                       contact="Tom Olson @tom.olson"/>
+        <tag name="KHX"         author="Khronos"                       contact="Tom Olson @tom.olson"/>
+        <tag name="EXT"         author="Multivendor"                   contact="Jon Leech @oddhack"/>
+        <tag name="MESA"        author="Mesa open source project"      contact="Chad Versace @chadversary, Daniel Stone @fooishbar, David Airlie @airlied, Jason Ekstrand @jekstrand"/>
     </tags>
 
-    <!-- SECTION: Vulkan type definitions -->
-    <types>
+    <types comment="Vulkan type definitions">
         <type name="vk_platform" category="include">#include "vk_platform.h"</type>
-            <!-- WSI extensions -->
+
+            <comment>WSI extensions</comment>
         <type category="include">#include "<name>vulkan.h</name>"</type>
         <type category="include">#include &lt;<name>X11/Xlib.h</name>&gt;</type>
+        <type category="include">#include &lt;<name>X11/extensions/Xrandr.h</name>&gt;</type>
         <type category="include">#include &lt;<name>android/native_window.h</name>&gt;</type>
         <type category="include">#include &lt;<name>mir_toolkit/client_types.h</name>&gt;</type>
         <type category="include">#include &lt;<name>wayland-client.h</name>&gt;</type>
@@ -79,6 +79,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <type requires="X11/Xlib.h" name="Display"/>
         <type requires="X11/Xlib.h" name="VisualID"/>
         <type requires="X11/Xlib.h" name="Window"/>
+        <type requires="X11/extensions/Xrandr.h" name="RROutput"/>
         <type requires="android/native_window.h" name="ANativeWindow"/>
         <type requires="mir_toolkit/client_types.h" name="MirConnection"/>
         <type requires="mir_toolkit/client_types.h" name="MirSurface"/>
@@ -89,6 +90,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <type requires="windows.h" name="HANDLE"/>
         <type requires="windows.h" name="SECURITY_ATTRIBUTES"/>
         <type requires="windows.h" name="DWORD"/>
+        <type requires="windows.h" name="LPCWSTR"/>
         <type requires="xcb/xcb.h" name="xcb_connection_t"/>
         <type requires="xcb/xcb.h" name="xcb_visualid_t"/>
         <type requires="xcb/xcb.h" name="xcb_window_t"/>
@@ -100,11 +102,11 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <type category="define">#define <name>VK_VERSION_PATCH</name>(version) ((uint32_t)(version) &amp; 0xfff)</type>
 
         <type category="define">// DEPRECATED: This define has been removed. Specific version defines (e.g. VK_API_VERSION_1_0), or the VK_MAKE_VERSION macro, should be used instead.
-//#define <name>VK_API_VERSION</name> <type>VK_MAKE_VERSION</type>(1, 0, 0)</type>    <!-- The patch version here should never be set to anything other than 0 -->
+//#define <name>VK_API_VERSION</name> <type>VK_MAKE_VERSION</type>(1, 0, 0) // Patch version should always be set to 0</type>
         <type category="define">// Vulkan 1.0 version number
-#define <name>VK_API_VERSION_1_0</name> <type>VK_MAKE_VERSION</type>(1, 0, 0)</type>    <!-- The patch version here should never be set to anything other than 0 -->
+#define <name>VK_API_VERSION_1_0</name> <type>VK_MAKE_VERSION</type>(1, 0, 0)// Patch version should always be set to 0</type>
         <type category="define">// Version of this file
-#define <name>VK_HEADER_VERSION</name> 37</type>
+#define <name>VK_HEADER_VERSION</name> 58</type>
 
         <type category="define">
 #define <name>VK_DEFINE_HANDLE</name>(object) typedef struct object##_T* object;</type>
@@ -127,7 +129,8 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <type category="basetype">typedef <type>uint32_t</type> <name>VkBool32</name>;</type>
         <type category="basetype">typedef <type>uint32_t</type> <name>VkFlags</name>;</type>
         <type category="basetype">typedef <type>uint64_t</type> <name>VkDeviceSize</name>;</type>
-        <!-- Basic C types, pulled in via vk_platform.h -->
+
+            <comment>Basic C types, pulled in via vk_platform.h</comment>
         <type requires="vk_platform" name="void"/>
         <type requires="vk_platform" name="char"/>
         <type requires="vk_platform" name="float"/>
@@ -136,88 +139,112 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <type requires="vk_platform" name="uint64_t"/>
         <type requires="vk_platform" name="int32_t"/>
         <type requires="vk_platform" name="size_t"/>
-        <!-- Bitmask types -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkFramebufferCreateFlags</name>;</type>               <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkQueryPoolCreateFlags</name>;</type>                 <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkRenderPassCreateFlags</name>;</type>                <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkSamplerCreateFlags</name>;</type>                   <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineLayoutCreateFlags</name>;</type>            <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineCacheCreateFlags</name>;</type>             <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineDepthStencilStateCreateFlags</name>;</type> <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineDynamicStateCreateFlags</name>;</type>      <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineColorBlendStateCreateFlags</name>;</type>   <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineMultisampleStateCreateFlags</name>;</type>  <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineRasterizationStateCreateFlags</name>;</type>       <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineViewportStateCreateFlags</name>;</type>     <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineTessellationStateCreateFlags</name>;</type> <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineInputAssemblyStateCreateFlags</name>;</type><!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineVertexInputStateCreateFlags</name>;</type>  <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineShaderStageCreateFlags</name>;</type>       <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDescriptorSetLayoutCreateFlags</name>;</type>       <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkBufferViewCreateFlags</name>;</type>                <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkInstanceCreateFlags</name>;</type>                  <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDeviceCreateFlags</name>;</type>                    <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDeviceQueueCreateFlags</name>;</type>               <!-- creation flags -->
-        <type requires="VkQueueFlagBits"                  category="bitmask">typedef <type>VkFlags</type> <name>VkQueueFlags</name>;</type>                       <!-- Queue capabilities -->
-        <type requires="VkMemoryPropertyFlagBits"         category="bitmask">typedef <type>VkFlags</type> <name>VkMemoryPropertyFlags</name>;</type>              <!-- Memory properties passed into vkAllocateMemory(). -->
-        <type requires="VkMemoryHeapFlagBits"             category="bitmask">typedef <type>VkFlags</type> <name>VkMemoryHeapFlags</name>;</type>                  <!-- Memory heap flags -->
-        <type requires="VkAccessFlagBits"                 category="bitmask">typedef <type>VkFlags</type> <name>VkAccessFlags</name>;</type>                      <!-- Memory access flags passed to barrier/dependency operations -->
-        <type requires="VkBufferUsageFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkBufferUsageFlags</name>;</type>                 <!-- Buffer usage flags -->
-        <type requires="VkBufferCreateFlagBits"           category="bitmask">typedef <type>VkFlags</type> <name>VkBufferCreateFlags</name>;</type>                <!-- Buffer creation flags -->
-        <type requires="VkShaderStageFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkShaderStageFlags</name>;</type>                 <!-- Shader stage flags -->
-        <type requires="VkImageUsageFlagBits"             category="bitmask">typedef <type>VkFlags</type> <name>VkImageUsageFlags</name>;</type>                  <!-- Image usage flags -->
-        <type requires="VkImageCreateFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkImageCreateFlags</name>;</type>                 <!-- Image creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkImageViewCreateFlags</name>;</type>             <!-- Image view creation flags (no bits yet) -->
-        <type requires="VkPipelineCreateFlagBits"         category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineCreateFlags</name>;</type>              <!-- Pipeline creation flags -->
-        <type requires="VkColorComponentFlagBits"         category="bitmask">typedef <type>VkFlags</type> <name>VkColorComponentFlags</name>;</type>              <!-- Color component flags -->
-        <type requires="VkFenceCreateFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkFenceCreateFlags</name>;</type>                 <!-- Fence creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkSemaphoreCreateFlags</name>;</type>             <!-- Semaphore creation flags -->
-        <type requires="VkFormatFeatureFlagBits"          category="bitmask">typedef <type>VkFlags</type> <name>VkFormatFeatureFlags</name>;</type>               <!-- Format capability flags -->
-        <type requires="VkQueryControlFlagBits"           category="bitmask">typedef <type>VkFlags</type> <name>VkQueryControlFlags</name>;</type>                <!-- Query control flags -->
-        <type requires="VkQueryResultFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkQueryResultFlags</name>;</type>                 <!-- Query result flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkShaderModuleCreateFlags</name>;</type>          <!-- Shader module creation flags (no bits yet) -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkEventCreateFlags</name>;</type>                 <!-- Event creation flags  (no bits yet) -->
-        <type requires="VkCommandPoolCreateFlagBits"          category="bitmask">typedef <type>VkFlags</type> <name>VkCommandPoolCreateFlags</name>;</type>               <!-- Command pool creation flags -->
-        <type requires="VkCommandPoolResetFlagBits"           category="bitmask">typedef <type>VkFlags</type> <name>VkCommandPoolResetFlags</name>;</type>                <!-- Command pool reset flags -->
-        <type requires="VkCommandBufferResetFlagBits"         category="bitmask">typedef <type>VkFlags</type> <name>VkCommandBufferResetFlags</name>;</type>              <!-- Command buffer reset flags -->
-        <type requires="VkCommandBufferUsageFlagBits"         category="bitmask">typedef <type>VkFlags</type> <name>VkCommandBufferUsageFlags</name>;</type>              <!-- Command buffer usage flags -->
-        <type requires="VkQueryPipelineStatisticFlagBits" category="bitmask">typedef <type>VkFlags</type> <name>VkQueryPipelineStatisticFlags</name>;</type>      <!-- Pipeline statistics flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkMemoryMapFlags</name>;</type>                   <!-- Memory mapping flags (no bits yet) -->
-        <type requires="VkImageAspectFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkImageAspectFlags</name>;</type>                 <!-- Bitmask of image aspects -->
-        <type requires="VkSparseMemoryBindFlagBits"       category="bitmask">typedef <type>VkFlags</type> <name>VkSparseMemoryBindFlags</name>;</type>            <!-- Sparse memory bind flags -->
-        <type requires="VkSparseImageFormatFlagBits"      category="bitmask">typedef <type>VkFlags</type> <name>VkSparseImageFormatFlags</name>;</type>           <!-- Sparse image memory requirements flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkSubpassDescriptionFlags</name>;</type>          <!-- Subpass description flags -->
-        <type requires="VkPipelineStageFlagBits"          category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineStageFlags</name>;</type>               <!-- Pipeline stages -->
-        <type requires="VkSampleCountFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkSampleCountFlags</name>;</type>                 <!-- Pipeline stages -->
-        <type requires="VkAttachmentDescriptionFlagBits"  category="bitmask">typedef <type>VkFlags</type> <name>VkAttachmentDescriptionFlags</name>;</type>       <!-- Render pass attachment description flags -->
-        <type requires="VkStencilFaceFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkStencilFaceFlags</name>;</type>                 <!-- Stencil face flags -->
-        <type requires="VkCullModeFlagBits"               category="bitmask">typedef <type>VkFlags</type> <name>VkCullModeFlags</name>;</type>                    <!-- Cull mode flags -->
-        <type requires="VkDescriptorPoolCreateFlagBits"   category="bitmask">typedef <type>VkFlags</type> <name>VkDescriptorPoolCreateFlags</name>;</type>        <!-- Descriptor pool creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDescriptorPoolResetFlags</name>;</type>         <!-- Descriptor pool reset flags -->
-        <type requires="VkDependencyFlagBits"             category="bitmask">typedef <type>VkFlags</type> <name>VkDependencyFlags</name>;</type>                  <!-- Pipeline barrier and subpass dependency flags -->
+        <type name="int"/>
 
-        <type requires="VkIndirectCommandsLayoutUsageFlagBitsNVX"  category="bitmask">typedef <type>VkFlags</type> <name>VkIndirectCommandsLayoutUsageFlagsNVX</name>;</type>  <!-- Device generated commands usage flags -->
-        <type requires="VkObjectEntryUsageFlagBitsNVX"             category="bitmask">typedef <type>VkFlags</type> <name>VkObjectEntryUsageFlagsNVX</name>;</type>             <!-- Object usage flags -->
+            <comment>Bitmask types</comment>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkFramebufferCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkQueryPoolCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkRenderPassCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkSamplerCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineLayoutCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineCacheCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineDepthStencilStateCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineDynamicStateCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineColorBlendStateCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineMultisampleStateCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineRasterizationStateCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineViewportStateCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineTessellationStateCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineInputAssemblyStateCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineVertexInputStateCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineShaderStageCreateFlags</name>;</type>
+        <type requires="VkDescriptorSetLayoutCreateFlagBits" category="bitmask">typedef <type>VkFlags</type> <name>VkDescriptorSetLayoutCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkBufferViewCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkInstanceCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDeviceCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDeviceQueueCreateFlags</name>;</type>
+        <type requires="VkQueueFlagBits"                  category="bitmask">typedef <type>VkFlags</type> <name>VkQueueFlags</name>;</type>
+        <type requires="VkMemoryPropertyFlagBits"         category="bitmask">typedef <type>VkFlags</type> <name>VkMemoryPropertyFlags</name>;</type>
+        <type requires="VkMemoryHeapFlagBits"             category="bitmask">typedef <type>VkFlags</type> <name>VkMemoryHeapFlags</name>;</type>
+        <type requires="VkAccessFlagBits"                 category="bitmask">typedef <type>VkFlags</type> <name>VkAccessFlags</name>;</type>
+        <type requires="VkBufferUsageFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkBufferUsageFlags</name>;</type>
+        <type requires="VkBufferCreateFlagBits"           category="bitmask">typedef <type>VkFlags</type> <name>VkBufferCreateFlags</name>;</type>
+        <type requires="VkShaderStageFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkShaderStageFlags</name>;</type>
+        <type requires="VkImageUsageFlagBits"             category="bitmask">typedef <type>VkFlags</type> <name>VkImageUsageFlags</name>;</type>
+        <type requires="VkImageCreateFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkImageCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkImageViewCreateFlags</name>;</type>
+        <type requires="VkPipelineCreateFlagBits"         category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineCreateFlags</name>;</type>
+        <type requires="VkColorComponentFlagBits"         category="bitmask">typedef <type>VkFlags</type> <name>VkColorComponentFlags</name>;</type>
+        <type requires="VkFenceCreateFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkFenceCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkSemaphoreCreateFlags</name>;</type>
+        <type requires="VkFormatFeatureFlagBits"          category="bitmask">typedef <type>VkFlags</type> <name>VkFormatFeatureFlags</name>;</type>
+        <type requires="VkQueryControlFlagBits"           category="bitmask">typedef <type>VkFlags</type> <name>VkQueryControlFlags</name>;</type>
+        <type requires="VkQueryResultFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkQueryResultFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkShaderModuleCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkEventCreateFlags</name>;</type>
+        <type requires="VkCommandPoolCreateFlagBits"          category="bitmask">typedef <type>VkFlags</type> <name>VkCommandPoolCreateFlags</name>;</type>
+        <type requires="VkCommandPoolResetFlagBits"           category="bitmask">typedef <type>VkFlags</type> <name>VkCommandPoolResetFlags</name>;</type>
+        <type requires="VkCommandBufferResetFlagBits"         category="bitmask">typedef <type>VkFlags</type> <name>VkCommandBufferResetFlags</name>;</type>
+        <type requires="VkCommandBufferUsageFlagBits"         category="bitmask">typedef <type>VkFlags</type> <name>VkCommandBufferUsageFlags</name>;</type>
+        <type requires="VkQueryPipelineStatisticFlagBits" category="bitmask">typedef <type>VkFlags</type> <name>VkQueryPipelineStatisticFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkMemoryMapFlags</name>;</type>
+        <type requires="VkImageAspectFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkImageAspectFlags</name>;</type>
+        <type requires="VkSparseMemoryBindFlagBits"       category="bitmask">typedef <type>VkFlags</type> <name>VkSparseMemoryBindFlags</name>;</type>
+        <type requires="VkSparseImageFormatFlagBits"      category="bitmask">typedef <type>VkFlags</type> <name>VkSparseImageFormatFlags</name>;</type>
+        <type requires="VkSubpassDescriptionFlagBits"     category="bitmask">typedef <type>VkFlags</type> <name>VkSubpassDescriptionFlags</name>;</type>
+        <type requires="VkPipelineStageFlagBits"          category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineStageFlags</name>;</type>
+        <type requires="VkSampleCountFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkSampleCountFlags</name>;</type>
+        <type requires="VkAttachmentDescriptionFlagBits"  category="bitmask">typedef <type>VkFlags</type> <name>VkAttachmentDescriptionFlags</name>;</type>
+        <type requires="VkStencilFaceFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkStencilFaceFlags</name>;</type>
+        <type requires="VkCullModeFlagBits"               category="bitmask">typedef <type>VkFlags</type> <name>VkCullModeFlags</name>;</type>
+        <type requires="VkDescriptorPoolCreateFlagBits"   category="bitmask">typedef <type>VkFlags</type> <name>VkDescriptorPoolCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDescriptorPoolResetFlags</name>;</type>
+        <type requires="VkDependencyFlagBits"             category="bitmask">typedef <type>VkFlags</type> <name>VkDependencyFlags</name>;</type>
 
-            <!-- WSI extensions -->
+        <type requires="VkIndirectCommandsLayoutUsageFlagBitsNVX"  category="bitmask">typedef <type>VkFlags</type> <name>VkIndirectCommandsLayoutUsageFlagsNVX</name>;</type>
+        <type requires="VkObjectEntryUsageFlagBitsNVX"             category="bitmask">typedef <type>VkFlags</type> <name>VkObjectEntryUsageFlagsNVX</name>;</type>
+
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDescriptorUpdateTemplateCreateFlagsKHR</name>;</type>
+
+            <comment>WSI extensions</comment>
         <type requires="VkCompositeAlphaFlagBitsKHR"      category="bitmask">typedef <type>VkFlags</type> <name>VkCompositeAlphaFlagsKHR</name>;</type>
         <type requires="VkDisplayPlaneAlphaFlagBitsKHR"   category="bitmask">typedef <type>VkFlags</type> <name>VkDisplayPlaneAlphaFlagsKHR</name>;</type>
         <type requires="VkSurfaceTransformFlagBitsKHR"    category="bitmask">typedef <type>VkFlags</type> <name>VkSurfaceTransformFlagsKHR</name>;</type>
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkSwapchainCreateFlagsKHR</name>;</type>          <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDisplayModeCreateFlagsKHR</name>;</type>        <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDisplaySurfaceCreateFlagsKHR</name>;</type>     <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkAndroidSurfaceCreateFlagsKHR</name>;</type>     <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkMirSurfaceCreateFlagsKHR</name>;</type>         <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkWaylandSurfaceCreateFlagsKHR</name>;</type>     <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkWin32SurfaceCreateFlagsKHR</name>;</type>       <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkXlibSurfaceCreateFlagsKHR</name>;</type>        <!-- creation flags -->
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkXcbSurfaceCreateFlagsKHR</name>;</type>         <!-- creation flags -->
+        <type requires="VkSwapchainCreateFlagBitsKHR"     category="bitmask">typedef <type>VkFlags</type> <name>VkSwapchainCreateFlagsKHR</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDisplayModeCreateFlagsKHR</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDisplaySurfaceCreateFlagsKHR</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkAndroidSurfaceCreateFlagsKHR</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkMirSurfaceCreateFlagsKHR</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkViSurfaceCreateFlagsNN</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkWaylandSurfaceCreateFlagsKHR</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkWin32SurfaceCreateFlagsKHR</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkXlibSurfaceCreateFlagsKHR</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkXcbSurfaceCreateFlagsKHR</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkIOSSurfaceCreateFlagsMVK</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkMacOSSurfaceCreateFlagsMVK</name>;</type>
+        <type requires="VkPeerMemoryFeatureFlagBitsKHX"   category="bitmask">typedef <type>VkFlags</type> <name>VkPeerMemoryFeatureFlagsKHX</name>;</type>
+        <type requires="VkMemoryAllocateFlagBitsKHX"      category="bitmask">typedef <type>VkFlags</type> <name>VkMemoryAllocateFlagsKHX</name>;</type>
+        <type requires="VkDeviceGroupPresentModeFlagBitsKHX" category="bitmask">typedef <type>VkFlags</type> <name>VkDeviceGroupPresentModeFlagsKHX</name>;</type>
 
         <type requires="VkDebugReportFlagBitsEXT"      category="bitmask">typedef <type>VkFlags</type> <name>VkDebugReportFlagsEXT</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkCommandPoolTrimFlagsKHR</name>;</type>
         <type requires="VkExternalMemoryHandleTypeFlagBitsNV" category="bitmask">typedef <type>VkFlags</type> <name>VkExternalMemoryHandleTypeFlagsNV</name>;</type>
         <type requires="VkExternalMemoryFeatureFlagBitsNV" category="bitmask">typedef <type>VkFlags</type> <name>VkExternalMemoryFeatureFlagsNV</name>;</type>
+        <type requires="VkExternalMemoryHandleTypeFlagBitsKHR" category="bitmask">typedef <type>VkFlags</type> <name>VkExternalMemoryHandleTypeFlagsKHR</name>;</type>
+        <type requires="VkExternalMemoryFeatureFlagBitsKHR" category="bitmask">typedef <type>VkFlags</type> <name>VkExternalMemoryFeatureFlagsKHR</name>;</type>
+        <type requires="VkExternalSemaphoreHandleTypeFlagBitsKHR" category="bitmask">typedef <type>VkFlags</type> <name>VkExternalSemaphoreHandleTypeFlagsKHR</name>;</type>
+        <type requires="VkExternalSemaphoreFeatureFlagBitsKHR" category="bitmask">typedef <type>VkFlags</type> <name>VkExternalSemaphoreFeatureFlagsKHR</name>;</type>
+        <type requires="VkSemaphoreImportFlagBitsKHR" category="bitmask">typedef <type>VkFlags</type> <name>VkSemaphoreImportFlagsKHR</name>;</type>
+        <type requires="VkExternalFenceHandleTypeFlagBitsKHR" category="bitmask">typedef <type>VkFlags</type> <name>VkExternalFenceHandleTypeFlagsKHR</name>;</type>
+        <type requires="VkExternalFenceFeatureFlagBitsKHR" category="bitmask">typedef <type>VkFlags</type> <name>VkExternalFenceFeatureFlagsKHR</name>;</type>
+        <type requires="VkFenceImportFlagBitsKHR" category="bitmask">typedef <type>VkFlags</type> <name>VkFenceImportFlagsKHR</name>;</type>
+        <type requires="VkSurfaceCounterFlagBitsEXT"      category="bitmask">typedef <type>VkFlags</type> <name>VkSurfaceCounterFlagsEXT</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineViewportSwizzleStateCreateFlagsNV</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineDiscardRectangleStateCreateFlagsEXT</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineCoverageToColorStateCreateFlagsNV</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineCoverageModulationStateCreateFlagsNV</name>;</type>
 
-        <!-- Types which can be void pointers or class pointers, selected at compile time -->
+            <comment>Types which can be void pointers or class pointers, selected at compile time</comment>
         <type category="handle"><type>VK_DEFINE_HANDLE</type>(<name>VkInstance</name>)</type>
         <type category="handle" parent="VkInstance"><type>VK_DEFINE_HANDLE</type>(<name>VkPhysicalDevice</name>)</type>
         <type category="handle" parent="VkPhysicalDevice"><type>VK_DEFINE_HANDLE</type>(<name>VkDevice</name>)</type>
@@ -245,15 +272,16 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <type category="handle" parent="VkDevice"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkPipelineCache</name>)</type>
         <type category="handle" parent="VkDevice"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkObjectTableNVX</name>)</type>
         <type category="handle" parent="VkDevice"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkIndirectCommandsLayoutNVX</name>)</type>
+        <type category="handle" parent="VkDevice"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkDescriptorUpdateTemplateKHR</name>)</type>
 
-        <!-- WSI extensions -->
+            <comment>WSI extensions</comment>
         <type category="handle"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkDisplayKHR</name>)</type>
         <type category="handle" parent="VkPhysicalDevice,VkDisplayKHR"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkDisplayModeKHR</name>)</type>
         <type category="handle" parent="VkInstance"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkSurfaceKHR</name>)</type>
         <type category="handle" parent="VkSurfaceKHR"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkSwapchainKHR</name>)</type>
         <type category="handle" parent="VkInstance"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkDebugReportCallbackEXT</name>)</type>
 
-        <!-- Types generated from corresponding <enums> tags below -->
+            <comment>Types generated from corresponding enums tags below</comment>
         <type name="VkAttachmentLoadOp" category="enum"/>
         <type name="VkAttachmentStoreOp" category="enum"/>
         <type name="VkBlendFactor" category="enum"/>
@@ -340,11 +368,20 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <type name="VkAttachmentDescriptionFlagBits" category="enum"/>
         <type name="VkDescriptorPoolCreateFlagBits" category="enum"/>
         <type name="VkDependencyFlagBits" category="enum"/>
+        <type name="VkObjectType" category="enum"/>
+
+        <comment>Extensions</comment>
         <type name="VkIndirectCommandsLayoutUsageFlagBitsNVX" category="enum"/>
         <type name="VkIndirectCommandsTokenTypeNVX" category="enum"/>
         <type name="VkObjectEntryUsageFlagBitsNVX" category="enum"/>
         <type name="VkObjectEntryTypeNVX" category="enum"/>
-        <!-- WSI extensions -->
+        <type name="VkDescriptorUpdateTemplateTypeKHR" category="enum"/>
+        <type name="VkViewportCoordinateSwizzleNV" category="enum"/>
+        <type name="VkDiscardRectangleModeEXT" category="enum"/>
+        <type name="VkSubpassDescriptionFlagBits" category="enum"/>
+        <type name="VkCoverageModulationModeNV" category="enum"/>
+
+            <comment>WSI extensions</comment>
         <type name="VkColorSpaceKHR" category="enum"/>
         <type name="VkCompositeAlphaFlagBitsKHR" category="enum"/>
         <type name="VkDisplayPlaneAlphaFlagBitsKHR" category="enum"/>
@@ -352,13 +389,30 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <type name="VkSurfaceTransformFlagBitsKHR" category="enum"/>
         <type name="VkDebugReportFlagBitsEXT" category="enum"/>
         <type name="VkDebugReportObjectTypeEXT" category="enum"/>
-        <type name="VkDebugReportErrorEXT" category="enum"/>
         <type name="VkRasterizationOrderAMD" category="enum"/>
         <type name="VkExternalMemoryHandleTypeFlagBitsNV" category="enum"/>
         <type name="VkExternalMemoryFeatureFlagBitsNV" category="enum"/>
         <type name="VkValidationCheckEXT" category="enum"/>
+        <type name="VkExternalMemoryHandleTypeFlagBitsKHR" category="enum"/>
+        <type name="VkExternalMemoryFeatureFlagBitsKHR" category="enum"/>
+        <type name="VkExternalSemaphoreHandleTypeFlagBitsKHR" category="enum"/>
+        <type name="VkExternalSemaphoreFeatureFlagBitsKHR" category="enum"/>
+        <type name="VkSemaphoreImportFlagBitsKHR" category="enum"/>
+        <type name="VkExternalFenceHandleTypeFlagBitsKHR" category="enum"/>
+        <type name="VkExternalFenceFeatureFlagBitsKHR" category="enum"/>
+        <type name="VkFenceImportFlagBitsKHR" category="enum"/>
+        <type name="VkSurfaceCounterFlagBitsEXT" category="enum"/>
+        <type name="VkDisplayPowerStateEXT" category="enum"/>
+        <type name="VkDeviceEventTypeEXT" category="enum"/>
+        <type name="VkDisplayEventTypeEXT" category="enum"/>
+        <type name="VkPeerMemoryFeatureFlagBitsKHX" category="enum"/>
+        <type name="VkMemoryAllocateFlagBitsKHX" category="enum"/>
+        <type name="VkDeviceGroupPresentModeFlagBitsKHX" category="enum"/>
+        <type name="VkSwapchainCreateFlagBitsKHR" category="enum"/>
+        <type name="VkSamplerReductionModeEXT" category="enum"/>
+        <type name="VkBlendOverlapEXT" category="enum"/>
 
-        <!-- The PFN_vk*Function types are used by VkAllocationCallbacks below -->
+            <comment>The PFN_vk*Function types are used by VkAllocationCallbacks below</comment>
         <type category="funcpointer">typedef void (VKAPI_PTR *<name>PFN_vkInternalAllocationNotification</name>)(
     <type>void</type>*                                       pUserData,
     <type>size_t</type>                                      size,
@@ -384,10 +438,10 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
     <type>void</type>*                                       pUserData,
     <type>void</type>*                                       pMemory);</type>
 
-    <!-- The PFN_vkVoidFunction type are used by VkGet*ProcAddr below -->
+            <comment>The PFN_vkVoidFunction type are used by VkGet*ProcAddr below</comment>
         <type category="funcpointer">typedef void (VKAPI_PTR *<name>PFN_vkVoidFunction</name>)(void);</type>
 
-    <!-- The PFN_vkDebugReportCallbackEXT type are used by the DEBUG_REPORT extension-->
+            <comment>The PFN_vkDebugReportCallbackEXT type are used by the DEBUG_REPORT extension</comment>
         <type category="funcpointer">typedef VkBool32 (VKAPI_PTR *<name>PFN_vkDebugReportCallbackEXT</name>)(
     <type>VkDebugReportFlagsEXT</type>                       flags,
     <type>VkDebugReportObjectTypeEXT</type>                  objectType,
@@ -398,7 +452,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
     const <type>char</type>*                                 pMessage,
     <type>void</type>*                                       pUserData);</type>
 
-        <!-- Struct types -->
+            <comment>Struct types</comment>
         <type category="struct" name="VkOffset2D">
             <member><type>int32_t</type>        <name>x</name></member>
             <member><type>int32_t</type>        <name>y</name></member>
@@ -456,18 +510,18 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member><type>VkPhysicalDeviceSparseProperties</type> <name>sparseProperties</name></member>
         </type>
         <type category="struct" name="VkExtensionProperties" returnedonly="true">
-            <member><type>char</type>            <name>extensionName</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]</member> <!-- extension name -->
-            <member><type>uint32_t</type>        <name>specVersion</name></member>                    <!-- version of the extension specification implemented -->
+            <member><type>char</type>            <name>extensionName</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]<comment>extension name</comment></member>
+            <member><type>uint32_t</type>        <name>specVersion</name><comment>version of the extension specification implemented</comment></member>
         </type>
         <type category="struct" name="VkLayerProperties" returnedonly="true">
-            <member><type>char</type>            <name>layerName</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]</member> <!-- layer name -->
-            <member><type>uint32_t</type>        <name>specVersion</name></member>                    <!-- version of the layer specification implemented -->
-            <member><type>uint32_t</type>        <name>implementationVersion</name></member>                    <!-- build or release version of the layer's library -->
-            <member><type>char</type>            <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member> <!-- Free-form description of the layer -->
+            <member><type>char</type>            <name>layerName</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]<comment>layer name</comment></member>
+            <member><type>uint32_t</type>        <name>specVersion</name><comment>version of the layer specification implemented</comment></member>
+            <member><type>uint32_t</type>        <name>implementationVersion</name><comment>build or release version of the layer's library</comment></member>
+            <member><type>char</type>            <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]<comment>Free-form description of the layer</comment></member>
         </type>
         <type category="struct" name="VkApplicationInfo">
             <member values="VK_STRUCTURE_TYPE_APPLICATION_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*     <name>pNext</name></member>                          <!-- Pointer to next structure -->
+            <member>const <type>void</type>*     <name>pNext</name></member>
             <member optional="true" len="null-terminated">const <type>char</type>*     <name>pApplicationName</name></member>
             <member><type>uint32_t</type>        <name>applicationVersion</name></member>
             <member optional="true" len="null-terminated">const <type>char</type>*     <name>pEngineName</name></member>
@@ -484,39 +538,39 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkDeviceQueueCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*     <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkDeviceQueueCreateFlags</type>    <name>flags</name></member>              <!-- Reserved -->
+            <member>const <type>void</type>*     <name>pNext</name></member>
+            <member optional="true"><type>VkDeviceQueueCreateFlags</type>    <name>flags</name></member>
             <member><type>uint32_t</type>        <name>queueFamilyIndex</name></member>
             <member><type>uint32_t</type>        <name>queueCount</name></member>
             <member len="queueCount">const <type>float</type>*    <name>pQueuePriorities</name></member>
         </type>
         <type category="struct" name="VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*     <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkDeviceCreateFlags</type>    <name>flags</name></member>                   <!-- Reserved -->
+            <member>const <type>void</type>*     <name>pNext</name></member>
+            <member optional="true"><type>VkDeviceCreateFlags</type>    <name>flags</name></member>
             <member><type>uint32_t</type>        <name>queueCreateInfoCount</name></member>
             <member len="queueCreateInfoCount">const <type>VkDeviceQueueCreateInfo</type>* <name>pQueueCreateInfos</name></member>
             <member optional="true"><type>uint32_t</type>               <name>enabledLayerCount</name></member>
-            <member len="enabledLayerCount,null-terminated">const <type>char</type>* const*      <name>ppEnabledLayerNames</name></member>            <!-- Ordered list of layer names to be enabled -->
+            <member len="enabledLayerCount,null-terminated">const <type>char</type>* const*      <name>ppEnabledLayerNames</name><comment>Ordered list of layer names to be enabled</comment></member>
             <member optional="true"><type>uint32_t</type>               <name>enabledExtensionCount</name></member>
             <member len="enabledExtensionCount,null-terminated">const <type>char</type>* const*      <name>ppEnabledExtensionNames</name></member>
             <member optional="true">const <type>VkPhysicalDeviceFeatures</type>* <name>pEnabledFeatures</name></member>
         </type>
         <type category="struct" name="VkInstanceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkInstanceCreateFlags</type>  <name>flags</name></member>                          <!-- Reserved -->
+            <member>const <type>void</type>*     <name>pNext</name></member>
+            <member optional="true"><type>VkInstanceCreateFlags</type>  <name>flags</name></member>
             <member optional="true">const <type>VkApplicationInfo</type>* <name>pApplicationInfo</name></member>
             <member optional="true"><type>uint32_t</type>               <name>enabledLayerCount</name></member>
-            <member len="enabledLayerCount,null-terminated">const <type>char</type>* const*      <name>ppEnabledLayerNames</name></member>            <!-- Ordered list of layer names to be enabled -->
+            <member len="enabledLayerCount,null-terminated">const <type>char</type>* const*      <name>ppEnabledLayerNames</name><comment>Ordered list of layer names to be enabled</comment></member>
             <member optional="true"><type>uint32_t</type>               <name>enabledExtensionCount</name></member>
-            <member len="enabledExtensionCount,null-terminated">const <type>char</type>* const*      <name>ppEnabledExtensionNames</name></member>        <!-- Extension names to be enabled -->
+            <member len="enabledExtensionCount,null-terminated">const <type>char</type>* const*      <name>ppEnabledExtensionNames</name><comment>Extension names to be enabled</comment></member>
         </type>
         <type category="struct" name="VkQueueFamilyProperties" returnedonly="true">
-            <member optional="true"><type>VkQueueFlags</type>           <name>queueFlags</name></member>                     <!-- Queue flags -->
+            <member optional="true"><type>VkQueueFlags</type>           <name>queueFlags</name><comment>Queue flags</comment></member>
             <member><type>uint32_t</type>               <name>queueCount</name></member>
             <member><type>uint32_t</type>               <name>timestampValidBits</name></member>
-            <member><type>VkExtent3D</type>             <name>minImageTransferGranularity</name></member>    <!-- Minimum alignment requirement for image transfers -->
+            <member><type>VkExtent3D</type>             <name>minImageTransferGranularity</name><comment>Minimum alignment requirement for image transfers</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMemoryProperties" returnedonly="true">
             <member><type>uint32_t</type>               <name>memoryTypeCount</name></member>
@@ -526,14 +580,14 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member validextensionstructs="VkDedicatedAllocationMemoryAllocateInfoNV">const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member><type>VkDeviceSize</type>           <name>allocationSize</name></member>                 <!-- Size of memory allocation -->
-            <member><type>uint32_t</type>               <name>memoryTypeIndex</name></member>                <!-- Index of the of the memory type to allocate from -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkDeviceSize</type>           <name>allocationSize</name><comment>Size of memory allocation</comment></member>
+            <member><type>uint32_t</type>               <name>memoryTypeIndex</name><comment>Index of the of the memory type to allocate from</comment></member>
         </type>
         <type category="struct" name="VkMemoryRequirements" returnedonly="true">
-            <member><type>VkDeviceSize</type>           <name>size</name></member>                           <!-- Specified in bytes -->
-            <member><type>VkDeviceSize</type>           <name>alignment</name></member>                      <!-- Specified in bytes -->
-            <member><type>uint32_t</type>               <name>memoryTypeBits</name></member>                 <!-- Bitmask of the allowed memory type indices into memoryTypes[] for this object -->
+            <member><type>VkDeviceSize</type>           <name>size</name><comment>Specified in bytes</comment></member>
+            <member><type>VkDeviceSize</type>           <name>alignment</name><comment>Specified in bytes</comment></member>
+            <member><type>uint32_t</type>               <name>memoryTypeBits</name><comment>Bitmask of the allowed memory type indices into memoryTypes[] for this object</comment></member>
         </type>
         <type category="struct" name="VkSparseImageFormatProperties" returnedonly="true">
             <member optional="true"><type>VkImageAspectFlags</type>     <name>aspectMask</name></member>
@@ -543,88 +597,88 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <type category="struct" name="VkSparseImageMemoryRequirements" returnedonly="true">
             <member><type>VkSparseImageFormatProperties</type> <name>formatProperties</name></member>
             <member><type>uint32_t</type>               <name>imageMipTailFirstLod</name></member>
-            <member><type>VkDeviceSize</type>           <name>imageMipTailSize</name></member>               <!-- Specified in bytes, must be a multiple of sparse block size in bytes / alignment -->
-            <member><type>VkDeviceSize</type>           <name>imageMipTailOffset</name></member>             <!-- Specified in bytes, must be a multiple of sparse block size in bytes / alignment -->
-            <member><type>VkDeviceSize</type>           <name>imageMipTailStride</name></member>             <!-- Specified in bytes, must be a multiple of sparse block size in bytes / alignment -->
+            <member><type>VkDeviceSize</type>           <name>imageMipTailSize</name><comment>Specified in bytes, must be a multiple of sparse block size in bytes / alignment</comment></member>
+            <member><type>VkDeviceSize</type>           <name>imageMipTailOffset</name><comment>Specified in bytes, must be a multiple of sparse block size in bytes / alignment</comment></member>
+            <member><type>VkDeviceSize</type>           <name>imageMipTailStride</name><comment>Specified in bytes, must be a multiple of sparse block size in bytes / alignment</comment></member>
         </type>
         <type category="struct" name="VkMemoryType" returnedonly="true">
-            <member optional="true"><type>VkMemoryPropertyFlags</type>  <name>propertyFlags</name></member>                  <!-- Memory properties of this memory type -->
-            <member><type>uint32_t</type>               <name>heapIndex</name></member>                      <!-- Index of the memory heap allocations of this memory type are taken from -->
+            <member optional="true"><type>VkMemoryPropertyFlags</type>  <name>propertyFlags</name><comment>Memory properties of this memory type</comment></member>
+            <member><type>uint32_t</type>               <name>heapIndex</name><comment>Index of the memory heap allocations of this memory type are taken from</comment></member>
         </type>
         <type category="struct" name="VkMemoryHeap" returnedonly="true">
-            <member><type>VkDeviceSize</type>           <name>size</name></member>                           <!-- Available memory in the heap-->
-            <member optional="true"><type>VkMemoryHeapFlags</type>      <name>flags</name></member>                          <!-- Flags for the heap-->
+            <member><type>VkDeviceSize</type>           <name>size</name><comment>Available memory in the heap</comment></member>
+            <member optional="true"><type>VkMemoryHeapFlags</type>      <name>flags</name><comment>Flags for the heap</comment></member>
         </type>
         <type category="struct" name="VkMappedMemoryRange">
             <member values="VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member><type>VkDeviceMemory</type>         <name>memory</name></member>                            <!-- Mapped memory object -->
-            <member><type>VkDeviceSize</type>           <name>offset</name></member>                         <!-- Offset within the memory object where the range starts -->
-            <member><type>VkDeviceSize</type>           <name>size</name></member>                           <!-- Size of the range within the memory object -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkDeviceMemory</type>         <name>memory</name><comment>Mapped memory object</comment></member>
+            <member><type>VkDeviceSize</type>           <name>offset</name><comment>Offset within the memory object where the range starts</comment></member>
+            <member><type>VkDeviceSize</type>           <name>size</name><comment>Size of the range within the memory object</comment></member>
         </type>
         <type category="struct" name="VkFormatProperties" returnedonly="true">
-            <member optional="true"><type>VkFormatFeatureFlags</type>   <name>linearTilingFeatures</name></member>           <!-- Format features in case of linear tiling -->
-            <member optional="true"><type>VkFormatFeatureFlags</type>   <name>optimalTilingFeatures</name></member>          <!-- Format features in case of optimal tiling -->
-            <member optional="true"><type>VkFormatFeatureFlags</type>   <name>bufferFeatures</name></member>                 <!-- Format features supported by buffers -->
+            <member optional="true"><type>VkFormatFeatureFlags</type>   <name>linearTilingFeatures</name><comment>Format features in case of linear tiling</comment></member>
+            <member optional="true"><type>VkFormatFeatureFlags</type>   <name>optimalTilingFeatures</name><comment>Format features in case of optimal tiling</comment></member>
+            <member optional="true"><type>VkFormatFeatureFlags</type>   <name>bufferFeatures</name><comment>Format features supported by buffers</comment></member>
         </type>
         <type category="struct" name="VkImageFormatProperties" returnedonly="true">
-            <member><type>VkExtent3D</type>             <name>maxExtent</name></member>                      <!-- max image dimensions for this resource type -->
-            <member><type>uint32_t</type>               <name>maxMipLevels</name></member>                   <!-- max number of mipmap levels for this resource type -->
-            <member><type>uint32_t</type>               <name>maxArrayLayers</name></member>                 <!-- max array size for this resource type -->
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>sampleCounts</name></member>                   <!-- supported sample counts for this resource type -->
-            <member><type>VkDeviceSize</type>           <name>maxResourceSize</name></member>                <!-- max size (in bytes) of this resource type -->
+            <member><type>VkExtent3D</type>             <name>maxExtent</name><comment>max image dimensions for this resource type</comment></member>
+            <member><type>uint32_t</type>               <name>maxMipLevels</name><comment>max number of mipmap levels for this resource type</comment></member>
+            <member><type>uint32_t</type>               <name>maxArrayLayers</name><comment>max array size for this resource type</comment></member>
+            <member optional="true"><type>VkSampleCountFlags</type>     <name>sampleCounts</name><comment>supported sample counts for this resource type</comment></member>
+            <member><type>VkDeviceSize</type>           <name>maxResourceSize</name><comment>max size (in bytes) of this resource type</comment></member>
         </type>
         <type category="struct" name="VkDescriptorBufferInfo">
-            <member><type>VkBuffer</type>               <name>buffer</name></member>                         <!-- Buffer used for this descriptor slot when the descriptor is UNIFORM_BUFFER[_DYNAMIC] or STORAGE_BUFFER[_DYNAMIC]. VK_NULL_HANDLE otherwise. -->
-            <member><type>VkDeviceSize</type>           <name>offset</name></member>                         <!-- Base offset from buffer start in bytes to update in the descriptor set. -->
-            <member><type>VkDeviceSize</type>           <name>range</name></member>                          <!-- Size in bytes of the buffer resource for this descriptor update. -->
+            <member><type>VkBuffer</type>               <name>buffer</name><comment>Buffer used for this descriptor slot when the descriptor is UNIFORM_BUFFER[_DYNAMIC] or STORAGE_BUFFER[_DYNAMIC]. VK_NULL_HANDLE otherwise.</comment></member>
+            <member><type>VkDeviceSize</type>           <name>offset</name><comment>Base offset from buffer start in bytes to update in the descriptor set.</comment></member>
+            <member><type>VkDeviceSize</type>           <name>range</name><comment>Size in bytes of the buffer resource for this descriptor update.</comment></member>
         </type>
         <type category="struct" name="VkDescriptorImageInfo">
-            <member noautovalidity="true"><type>VkSampler</type>       <name>sampler</name></member>                        <!-- Sampler to write to the descriptor in case it is a SAMPLER or COMBINED_IMAGE_SAMPLER descriptor. Ignored otherwise. -->
-            <member noautovalidity="true"><type>VkImageView</type>     <name>imageView</name></member>                      <!-- Image view to write to the descriptor in case it is a SAMPLED_IMAGE, STORAGE_IMAGE, COMBINED_IMAGE_SAMPLER, or INPUT_ATTACHMENT descriptor. Ignored otherwise. -->
-            <member noautovalidity="true"><type>VkImageLayout</type>   <name>imageLayout</name></member>                    <!-- Layout the image is expected to be in when accessed using this descriptor (only used if imageView is not VK_NULL_HANDLE). -->
+            <member noautovalidity="true"><type>VkSampler</type>       <name>sampler</name><comment>Sampler to write to the descriptor in case it is a SAMPLER or COMBINED_IMAGE_SAMPLER descriptor. Ignored otherwise.</comment></member>
+            <member noautovalidity="true"><type>VkImageView</type>     <name>imageView</name><comment>Image view to write to the descriptor in case it is a SAMPLED_IMAGE, STORAGE_IMAGE, COMBINED_IMAGE_SAMPLER, or INPUT_ATTACHMENT descriptor. Ignored otherwise.</comment></member>
+            <member noautovalidity="true"><type>VkImageLayout</type>   <name>imageLayout</name><comment>Layout the image is expected to be in when accessed using this descriptor (only used if imageView is not VK_NULL_HANDLE).</comment></member>
         </type>
         <type category="struct" name="VkWriteDescriptorSet">
             <member values="VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member><type>VkDescriptorSet</type>        <name>dstSet</name></member>                        <!-- Destination descriptor set -->
-            <member><type>uint32_t</type>               <name>dstBinding</name></member>                    <!-- Binding within the destination descriptor set to write -->
-            <member><type>uint32_t</type>               <name>dstArrayElement</name></member>               <!-- Array element within the destination binding to write -->
-            <member><type>uint32_t</type>               <name>descriptorCount</name></member>                          <!-- Number of descriptors to write (determines the size of the array pointed by pDescriptors) -->
-            <member><type>VkDescriptorType</type>       <name>descriptorType</name></member>                 <!-- Descriptor type to write (determines which members of the array pointed by pDescriptors are going to be used) -->
-            <member noautovalidity="true" len="descriptorCount">const <type>VkDescriptorImageInfo</type>* <name>pImageInfo</name></member>               <!-- Sampler, image view, and layout for SAMPLER, COMBINED_IMAGE_SAMPLER, {SAMPLED,STORAGE}_IMAGE, and INPUT_ATTACHMENT descriptor types. -->
-            <member noautovalidity="true" len="descriptorCount">const <type>VkDescriptorBufferInfo</type>* <name>pBufferInfo</name></member>             <!-- Raw buffer, size, and offset for {UNIFORM,STORAGE}_BUFFER[_DYNAMIC] descriptor types. -->
-            <member noautovalidity="true" len="descriptorCount">const <type>VkBufferView</type>*    <name>pTexelBufferView</name></member>               <!-- Buffer view to write to the descriptor for {UNIFORM,STORAGE}_TEXEL_BUFFER descriptor types. -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member noautovalidity="true"><type>VkDescriptorSet</type>        <name>dstSet</name><comment>Destination descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>dstBinding</name><comment>Binding within the destination descriptor set to write</comment></member>
+            <member><type>uint32_t</type>               <name>dstArrayElement</name><comment>Array element within the destination binding to write</comment></member>
+            <member><type>uint32_t</type>               <name>descriptorCount</name><comment>Number of descriptors to write (determines the size of the array pointed by pDescriptors)</comment></member>
+            <member><type>VkDescriptorType</type>       <name>descriptorType</name><comment>Descriptor type to write (determines which members of the array pointed by pDescriptors are going to be used)</comment></member>
+            <member noautovalidity="true" len="descriptorCount">const <type>VkDescriptorImageInfo</type>* <name>pImageInfo</name><comment>Sampler, image view, and layout for SAMPLER, COMBINED_IMAGE_SAMPLER, {SAMPLED,STORAGE}_IMAGE, and INPUT_ATTACHMENT descriptor types.</comment></member>
+            <member noautovalidity="true" len="descriptorCount">const <type>VkDescriptorBufferInfo</type>* <name>pBufferInfo</name><comment>Raw buffer, size, and offset for {UNIFORM,STORAGE}_BUFFER[_DYNAMIC] descriptor types.</comment></member>
+            <member noautovalidity="true" len="descriptorCount">const <type>VkBufferView</type>*    <name>pTexelBufferView</name><comment>Buffer view to write to the descriptor for {UNIFORM,STORAGE}_TEXEL_BUFFER descriptor types.</comment></member>
         </type>
         <type category="struct" name="VkCopyDescriptorSet">
             <member values="VK_STRUCTURE_TYPE_COPY_DESCRIPTOR_SET"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member><type>VkDescriptorSet</type>        <name>srcSet</name></member>                         <!-- Source descriptor set -->
-            <member><type>uint32_t</type>               <name>srcBinding</name></member>                     <!-- Binding within the source descriptor set to copy from -->
-            <member><type>uint32_t</type>               <name>srcArrayElement</name></member>                <!-- Array element within the source binding to copy from -->
-            <member><type>VkDescriptorSet</type>        <name>dstSet</name></member>                        <!-- Destination descriptor set -->
-            <member><type>uint32_t</type>               <name>dstBinding</name></member>                    <!-- Binding within the destination descriptor set to copy to -->
-            <member><type>uint32_t</type>               <name>dstArrayElement</name></member>               <!-- Array element within the destination binding to copy to -->
-            <member><type>uint32_t</type>               <name>descriptorCount</name></member>                <!-- Number of descriptors to write (determines the size of the array pointed by pDescriptors) -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkDescriptorSet</type>        <name>srcSet</name><comment>Source descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>srcBinding</name><comment>Binding within the source descriptor set to copy from</comment></member>
+            <member><type>uint32_t</type>               <name>srcArrayElement</name><comment>Array element within the source binding to copy from</comment></member>
+            <member><type>VkDescriptorSet</type>        <name>dstSet</name><comment>Destination descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>dstBinding</name><comment>Binding within the destination descriptor set to copy to</comment></member>
+            <member><type>uint32_t</type>               <name>dstArrayElement</name><comment>Array element within the destination binding to copy to</comment></member>
+            <member><type>uint32_t</type>               <name>descriptorCount</name><comment>Number of descriptors to write (determines the size of the array pointed by pDescriptors)</comment></member>
         </type>
         <type category="struct" name="VkBufferCreateInfo">
             <member values="VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member validextensionstructs="VkDedicatedAllocationBufferCreateInfoNV">const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure. -->
-            <member optional="true"><type>VkBufferCreateFlags</type>    <name>flags</name></member>                          <!-- Buffer creation flags -->
-            <member><type>VkDeviceSize</type>           <name>size</name></member>                           <!-- Specified in bytes -->
-            <member><type>VkBufferUsageFlags</type>     <name>usage</name></member>                          <!-- Buffer usage flags -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkBufferCreateFlags</type>    <name>flags</name><comment>Buffer creation flags</comment></member>
+            <member><type>VkDeviceSize</type>           <name>size</name><comment>Specified in bytes</comment></member>
+            <member><type>VkBufferUsageFlags</type>     <name>usage</name><comment>Buffer usage flags</comment></member>
             <member><type>VkSharingMode</type>          <name>sharingMode</name></member>
             <member optional="true"><type>uint32_t</type>               <name>queueFamilyIndexCount</name></member>
             <member noautovalidity="true" len="queueFamilyIndexCount">const <type>uint32_t</type>*        <name>pQueueFamilyIndices</name></member>
         </type>
         <type category="struct" name="VkBufferViewCreateInfo">
             <member values="VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure. -->
-            <member optional="true"><type>VkBufferViewCreateFlags</type><name>flags</name></member>                          <!-- Reserved -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkBufferViewCreateFlags</type><name>flags</name></member>
             <member><type>VkBuffer</type>               <name>buffer</name></member>
-            <member><type>VkFormat</type>               <name>format</name></member>                         <!-- Optionally specifies format of elements -->
-            <member><type>VkDeviceSize</type>           <name>offset</name></member>                         <!-- Specified in bytes -->
-            <member><type>VkDeviceSize</type>           <name>range</name></member>                          <!-- View size specified in bytes -->
+            <member><type>VkFormat</type>               <name>format</name><comment>Optionally specifies format of elements</comment></member>
+            <member><type>VkDeviceSize</type>           <name>offset</name><comment>Specified in bytes</comment></member>
+            <member><type>VkDeviceSize</type>           <name>range</name><comment>View size specified in bytes</comment></member>
         </type>
         <type category="struct" name="VkImageSubresource">
             <member><type>VkImageAspectFlags</type>     <name>aspectMask</name></member>
@@ -646,37 +700,37 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkMemoryBarrier">
             <member values="VK_STRUCTURE_TYPE_MEMORY_BARRIER"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure. -->
-            <member optional="true"><type>VkAccessFlags</type>          <name>srcAccessMask</name></member>                  <!-- Memory accesses from the source of the dependency to synchronize -->
-            <member optional="true"><type>VkAccessFlags</type>          <name>dstAccessMask</name></member>                  <!-- Memory accesses from the destination of the dependency to synchronize -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkAccessFlags</type>          <name>srcAccessMask</name><comment>Memory accesses from the source of the dependency to synchronize</comment></member>
+            <member optional="true"><type>VkAccessFlags</type>          <name>dstAccessMask</name><comment>Memory accesses from the destination of the dependency to synchronize</comment></member>
         </type>
         <type category="struct" name="VkBufferMemoryBarrier">
             <member values="VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure. -->
-            <member optional="true"><type>VkAccessFlags</type>          <name>srcAccessMask</name></member>                  <!-- Memory accesses from the source of the dependency to synchronize -->
-            <member optional="true"><type>VkAccessFlags</type>          <name>dstAccessMask</name></member>                  <!-- Memory accesses from the destination of the dependency to synchronize -->
-            <member><type>uint32_t</type>               <name>srcQueueFamilyIndex</name></member>            <!-- Queue family to transition ownership from -->
-            <member><type>uint32_t</type>               <name>dstQueueFamilyIndex</name></member>           <!-- Queue family to transition ownership to -->
-            <member><type>VkBuffer</type>               <name>buffer</name></member>                         <!-- Buffer to sync -->
-            <member><type>VkDeviceSize</type>           <name>offset</name></member>                         <!-- Offset within the buffer to sync -->
-            <member><type>VkDeviceSize</type>           <name>size</name></member>                           <!-- Amount of bytes to sync -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkAccessFlags</type>          <name>srcAccessMask</name><comment>Memory accesses from the source of the dependency to synchronize</comment></member>
+            <member optional="true"><type>VkAccessFlags</type>          <name>dstAccessMask</name><comment>Memory accesses from the destination of the dependency to synchronize</comment></member>
+            <member><type>uint32_t</type>               <name>srcQueueFamilyIndex</name><comment>Queue family to transition ownership from</comment></member>
+            <member><type>uint32_t</type>               <name>dstQueueFamilyIndex</name><comment>Queue family to transition ownership to</comment></member>
+            <member><type>VkBuffer</type>               <name>buffer</name><comment>Buffer to sync</comment></member>
+            <member><type>VkDeviceSize</type>           <name>offset</name><comment>Offset within the buffer to sync</comment></member>
+            <member><type>VkDeviceSize</type>           <name>size</name><comment>Amount of bytes to sync</comment></member>
         </type>
         <type category="struct" name="VkImageMemoryBarrier">
             <member values="VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure. -->
-            <member optional="true"><type>VkAccessFlags</type>          <name>srcAccessMask</name></member>                  <!-- Memory accesses from the source of the dependency to synchronize -->
-            <member optional="true"><type>VkAccessFlags</type>          <name>dstAccessMask</name></member>                  <!-- Memory accesses from the destination of the dependency to synchronize -->
-            <member><type>VkImageLayout</type>          <name>oldLayout</name></member>                      <!-- Current layout of the image -->
-            <member><type>VkImageLayout</type>          <name>newLayout</name></member>                      <!-- New layout to transition the image to -->
-            <member><type>uint32_t</type>               <name>srcQueueFamilyIndex</name></member>            <!-- Queue family to transition ownership from -->
-            <member><type>uint32_t</type>               <name>dstQueueFamilyIndex</name></member>           <!-- Queue family to transition ownership to -->
-            <member><type>VkImage</type>                <name>image</name></member>                          <!-- Image to sync -->
-            <member><type>VkImageSubresourceRange</type> <name>subresourceRange</name></member>              <!-- Subresource range to sync -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkAccessFlags</type>          <name>srcAccessMask</name><comment>Memory accesses from the source of the dependency to synchronize</comment></member>
+            <member optional="true"><type>VkAccessFlags</type>          <name>dstAccessMask</name><comment>Memory accesses from the destination of the dependency to synchronize</comment></member>
+            <member><type>VkImageLayout</type>          <name>oldLayout</name><comment>Current layout of the image</comment></member>
+            <member><type>VkImageLayout</type>          <name>newLayout</name><comment>New layout to transition the image to</comment></member>
+            <member><type>uint32_t</type>               <name>srcQueueFamilyIndex</name><comment>Queue family to transition ownership from</comment></member>
+            <member><type>uint32_t</type>               <name>dstQueueFamilyIndex</name><comment>Queue family to transition ownership to</comment></member>
+            <member><type>VkImage</type>                <name>image</name><comment>Image to sync</comment></member>
+            <member><type>VkImageSubresourceRange</type> <name>subresourceRange</name><comment>Subresource range to sync</comment></member>
         </type>
         <type category="struct" name="VkImageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member validextensionstructs="VkDedicatedAllocationImageCreateInfoNV">const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure. -->
-            <member optional="true"><type>VkImageCreateFlags</type>     <name>flags</name></member>                          <!-- Image creation flags -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkImageCreateFlags</type>     <name>flags</name><comment>Image creation flags</comment></member>
             <member><type>VkImageType</type>            <name>imageType</name></member>
             <member><type>VkFormat</type>               <name>format</name></member>
             <member><type>VkExtent3D</type>             <name>extent</name></member>
@@ -684,23 +738,23 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member><type>uint32_t</type>               <name>arrayLayers</name></member>
             <member><type>VkSampleCountFlagBits</type>  <name>samples</name></member>
             <member><type>VkImageTiling</type>          <name>tiling</name></member>
-            <member><type>VkImageUsageFlags</type>      <name>usage</name></member>                          <!-- Image usage flags -->
-            <member><type>VkSharingMode</type>          <name>sharingMode</name></member>                    <!-- Cross-queue-family sharing mode -->
-            <member optional="true"><type>uint32_t</type>               <name>queueFamilyIndexCount</name></member>          <!-- Number of queue families to share across -->
-            <member noautovalidity="true" len="queueFamilyIndexCount">const <type>uint32_t</type>*        <name>pQueueFamilyIndices</name></member>            <!-- Array of queue family indices to share across -->
-            <member><type>VkImageLayout</type>          <name>initialLayout</name></member>                  <!-- Initial image layout for all subresources -->
+            <member><type>VkImageUsageFlags</type>      <name>usage</name><comment>Image usage flags</comment></member>
+            <member><type>VkSharingMode</type>          <name>sharingMode</name><comment>Cross-queue-family sharing mode</comment></member>
+            <member optional="true"><type>uint32_t</type>               <name>queueFamilyIndexCount</name><comment>Number of queue families to share across</comment></member>
+            <member noautovalidity="true" len="queueFamilyIndexCount">const <type>uint32_t</type>*        <name>pQueueFamilyIndices</name><comment>Array of queue family indices to share across</comment></member>
+            <member><type>VkImageLayout</type>          <name>initialLayout</name><comment>Initial image layout for all subresources</comment></member>
         </type>
         <type category="struct" name="VkSubresourceLayout" returnedonly="true">
-            <member><type>VkDeviceSize</type>           <name>offset</name></member>                         <!-- Specified in bytes -->
-            <member><type>VkDeviceSize</type>           <name>size</name></member>                           <!-- Specified in bytes -->
-            <member><type>VkDeviceSize</type>           <name>rowPitch</name></member>                       <!-- Specified in bytes -->
-            <member><type>VkDeviceSize</type>           <name>arrayPitch</name></member>                     <!-- Specified in bytes -->
-            <member><type>VkDeviceSize</type>           <name>depthPitch</name></member>                     <!-- Specified in bytes -->
+            <member><type>VkDeviceSize</type>           <name>offset</name><comment>Specified in bytes</comment></member>
+            <member><type>VkDeviceSize</type>           <name>size</name><comment>Specified in bytes</comment></member>
+            <member><type>VkDeviceSize</type>           <name>rowPitch</name><comment>Specified in bytes</comment></member>
+            <member><type>VkDeviceSize</type>           <name>arrayPitch</name><comment>Specified in bytes</comment></member>
+            <member><type>VkDeviceSize</type>           <name>depthPitch</name><comment>Specified in bytes</comment></member>
         </type>
         <type category="struct" name="VkImageViewCreateInfo">
             <member values="VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkImageViewCreateFlags</type> <name>flags</name></member>                          <!-- Reserved -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkImageViewCreateFlags</type> <name>flags</name></member>
             <member><type>VkImage</type>                <name>image</name></member>
             <member><type>VkImageViewType</type>        <name>viewType</name></member>
             <member><type>VkFormat</type>               <name>format</name></member>
@@ -708,24 +762,24 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member><type>VkImageSubresourceRange</type> <name>subresourceRange</name></member>
         </type>
         <type category="struct" name="VkBufferCopy">
-            <member><type>VkDeviceSize</type>           <name>srcOffset</name></member>                      <!-- Specified in bytes -->
-            <member><type>VkDeviceSize</type>           <name>dstOffset</name></member>                     <!-- Specified in bytes -->
-            <member><type>VkDeviceSize</type>           <name>size</name></member>                           <!-- Specified in bytes -->
+            <member><type>VkDeviceSize</type>           <name>srcOffset</name><comment>Specified in bytes</comment></member>
+            <member><type>VkDeviceSize</type>           <name>dstOffset</name><comment>Specified in bytes</comment></member>
+            <member><type>VkDeviceSize</type>           <name>size</name><comment>Specified in bytes</comment></member>
         </type>
         <type category="struct" name="VkSparseMemoryBind">
-            <member><type>VkDeviceSize</type>           <name>resourceOffset</name></member>                 <!-- Specified in bytes -->
-            <member><type>VkDeviceSize</type>           <name>size</name></member>                           <!-- Specified in bytes -->
+            <member><type>VkDeviceSize</type>           <name>resourceOffset</name><comment>Specified in bytes</comment></member>
+            <member><type>VkDeviceSize</type>           <name>size</name><comment>Specified in bytes</comment></member>
             <member optional="true"><type>VkDeviceMemory</type>         <name>memory</name></member>
-            <member><type>VkDeviceSize</type>           <name>memoryOffset</name></member>                   <!-- Specified in bytes -->
-            <member optional="true"><type>VkSparseMemoryBindFlags</type><name>flags</name></member>                          <!-- Reserved for future -->
+            <member><type>VkDeviceSize</type>           <name>memoryOffset</name><comment>Specified in bytes</comment></member>
+            <member optional="true"><type>VkSparseMemoryBindFlags</type><name>flags</name></member>
         </type>
         <type category="struct" name="VkSparseImageMemoryBind">
             <member><type>VkImageSubresource</type>     <name>subresource</name></member>
             <member><type>VkOffset3D</type>             <name>offset</name></member>
             <member><type>VkExtent3D</type>             <name>extent</name></member>
             <member optional="true"><type>VkDeviceMemory</type>         <name>memory</name></member>
-            <member><type>VkDeviceSize</type>           <name>memoryOffset</name></member>                   <!-- Specified in bytes -->
-            <member optional="true"><type>VkSparseMemoryBindFlags</type><name>flags</name></member>                          <!-- Reserved for future -->
+            <member><type>VkDeviceSize</type>           <name>memoryOffset</name><comment>Specified in bytes</comment></member>
+            <member optional="true"><type>VkSparseMemoryBindFlags</type><name>flags</name></member>
         </type>
         <type category="struct" name="VkSparseBufferMemoryBindInfo">
             <member><type>VkBuffer</type> <name>buffer</name></member>
@@ -744,7 +798,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkBindSparseInfo">
             <member values="VK_STRUCTURE_TYPE_BIND_SPARSE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure. -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>               <name>waitSemaphoreCount</name></member>
             <member len="waitSemaphoreCount">const <type>VkSemaphore</type>*     <name>pWaitSemaphores</name></member>
             <member optional="true"><type>uint32_t</type>               <name>bufferBindCount</name></member>
@@ -758,24 +812,24 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkImageCopy">
             <member><type>VkImageSubresourceLayers</type> <name>srcSubresource</name></member>
-            <member><type>VkOffset3D</type>             <name>srcOffset</name></member>                      <!-- Specified in pixels for both compressed and uncompressed images -->
+            <member><type>VkOffset3D</type>             <name>srcOffset</name><comment>Specified in pixels for both compressed and uncompressed images</comment></member>
             <member><type>VkImageSubresourceLayers</type> <name>dstSubresource</name></member>
-            <member><type>VkOffset3D</type>             <name>dstOffset</name></member>                     <!-- Specified in pixels for both compressed and uncompressed images -->
-            <member><type>VkExtent3D</type>             <name>extent</name></member>                         <!-- Specified in pixels for both compressed and uncompressed images -->
+            <member><type>VkOffset3D</type>             <name>dstOffset</name><comment>Specified in pixels for both compressed and uncompressed images</comment></member>
+            <member><type>VkExtent3D</type>             <name>extent</name><comment>Specified in pixels for both compressed and uncompressed images</comment></member>
         </type>
         <type category="struct" name="VkImageBlit">
             <member><type>VkImageSubresourceLayers</type> <name>srcSubresource</name></member>
-            <member><type>VkOffset3D</type>             <name>srcOffsets</name>[2]</member>                      <!-- Specified in pixels for both compressed and uncompressed images -->
+            <member><type>VkOffset3D</type>             <name>srcOffsets</name>[2]<comment>Specified in pixels for both compressed and uncompressed images</comment></member>
             <member><type>VkImageSubresourceLayers</type> <name>dstSubresource</name></member>
-            <member><type>VkOffset3D</type>             <name>dstOffsets</name>[2]</member>                     <!-- Specified in pixels for both compressed and uncompressed images -->
+            <member><type>VkOffset3D</type>             <name>dstOffsets</name>[2]<comment>Specified in pixels for both compressed and uncompressed images</comment></member>
         </type>
         <type category="struct" name="VkBufferImageCopy">
-            <member><type>VkDeviceSize</type>           <name>bufferOffset</name></member>                   <!-- Specified in bytes -->
-            <member><type>uint32_t</type>               <name>bufferRowLength</name></member>                <!-- Specified in texels -->
+            <member><type>VkDeviceSize</type>           <name>bufferOffset</name><comment>Specified in bytes</comment></member>
+            <member><type>uint32_t</type>               <name>bufferRowLength</name><comment>Specified in texels</comment></member>
             <member><type>uint32_t</type>               <name>bufferImageHeight</name></member>
             <member><type>VkImageSubresourceLayers</type> <name>imageSubresource</name></member>
-            <member><type>VkOffset3D</type>             <name>imageOffset</name></member>                    <!-- Specified in pixels for both compressed and uncompressed images -->
-            <member><type>VkExtent3D</type>             <name>imageExtent</name></member>                    <!-- Specified in pixels for both compressed and uncompressed images -->
+            <member><type>VkOffset3D</type>             <name>imageOffset</name><comment>Specified in pixels for both compressed and uncompressed images</comment></member>
+            <member><type>VkExtent3D</type>             <name>imageExtent</name><comment>Specified in pixels for both compressed and uncompressed images</comment></member>
         </type>
         <type category="struct" name="VkImageResolve">
             <member><type>VkImageSubresourceLayers</type> <name>srcSubresource</name></member>
@@ -786,24 +840,24 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkShaderModuleCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkShaderModuleCreateFlags</type> <name>flags</name></member>                       <!-- Reserved -->
-            <member><type>size_t</type>                 <name>codeSize</name></member>                       <!-- Specified in bytes -->
-            <member len="latexmath:[$codeSize \over 4$]">const <type>uint32_t</type>*            <name>pCode</name></member>                          <!-- Binary code of size codeSize -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkShaderModuleCreateFlags</type> <name>flags</name></member>
+            <member><type>size_t</type>                 <name>codeSize</name><comment>Specified in bytes</comment></member>
+            <member len="latexmath:[codeSize \over 4]">const <type>uint32_t</type>*            <name>pCode</name><comment>Binary code of size codeSize</comment></member>
         </type>
         <type category="struct" name="VkDescriptorSetLayoutBinding">
-            <member><type>uint32_t</type>               <name>binding</name></member>                        <!-- Binding number for this entry -->
-            <member><type>VkDescriptorType</type>       <name>descriptorType</name></member>                 <!-- Type of the descriptors in this binding -->
-            <member optional="true"><type>uint32_t</type> <name>descriptorCount</name></member>              <!-- Number of descriptors in this binding -->
-            <member noautovalidity="true"><type>VkShaderStageFlags</type>     <name>stageFlags</name></member>                     <!-- Shader stages this binding is visible to -->
-            <member noautovalidity="true" optional="true" len="descriptorCount">const <type>VkSampler</type>*       <name>pImmutableSamplers</name></member>             <!-- Immutable samplers (used if descriptor type is SAMPLER or COMBINED_IMAGE_SAMPLER, is either NULL or contains count number of elements) -->
+            <member><type>uint32_t</type>               <name>binding</name><comment>Binding number for this entry</comment></member>
+            <member><type>VkDescriptorType</type>       <name>descriptorType</name><comment>Type of the descriptors in this binding</comment></member>
+            <member optional="true"><type>uint32_t</type> <name>descriptorCount</name><comment>Number of descriptors in this binding</comment></member>
+            <member noautovalidity="true"><type>VkShaderStageFlags</type>     <name>stageFlags</name><comment>Shader stages this binding is visible to</comment></member>
+            <member noautovalidity="true" optional="true" len="descriptorCount">const <type>VkSampler</type>*       <name>pImmutableSamplers</name><comment>Immutable samplers (used if descriptor type is SAMPLER or COMBINED_IMAGE_SAMPLER, is either NULL or contains count number of elements)</comment></member>
         </type>
         <type category="struct" name="VkDescriptorSetLayoutCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkDescriptorSetLayoutCreateFlags</type>    <name>flags</name></member>             <!-- Reserved -->
-            <member optional="true"><type>uint32_t</type>               <name>bindingCount</name></member>                   <!-- Number of bindings in the descriptor set layout -->
-            <member len="bindingCount">const <type>VkDescriptorSetLayoutBinding</type>* <name>pBindings</name></member>       <!-- Array of descriptor set layout bindings -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkDescriptorSetLayoutCreateFlags</type>    <name>flags</name></member>
+            <member optional="true"><type>uint32_t</type>               <name>bindingCount</name><comment>Number of bindings in the descriptor set layout</comment></member>
+            <member len="bindingCount">const <type>VkDescriptorSetLayoutBinding</type>* <name>pBindings</name><comment>Array of descriptor set layout bindings</comment></member>
         </type>
         <type category="struct" name="VkDescriptorPoolSize">
             <member><type>VkDescriptorType</type>       <name>type</name></member>
@@ -811,7 +865,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkDescriptorPoolCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkDescriptorPoolCreateFlags</type>  <name>flags</name></member>
             <member><type>uint32_t</type>               <name>maxSets</name></member>
             <member><type>uint32_t</type>               <name>poolSizeCount</name></member>
@@ -819,77 +873,77 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkDescriptorSetAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkDescriptorPool</type>       <name>descriptorPool</name></member>
             <member><type>uint32_t</type>               <name>descriptorSetCount</name></member>
             <member len="descriptorSetCount">const <type>VkDescriptorSetLayout</type>* <name>pSetLayouts</name></member>
         </type>
         <type category="struct" name="VkSpecializationMapEntry">
-            <member><type>uint32_t</type>               <name>constantID</name></member>                     <!-- The SpecConstant ID specified in the BIL -->
-            <member><type>uint32_t</type>               <name>offset</name></member>                         <!-- Offset of the value in the data block -->
-            <member><type>size_t</type>                 <name>size</name></member>                           <!-- Size in bytes of the SpecConstant -->
+            <member><type>uint32_t</type>               <name>constantID</name><comment>The SpecConstant ID specified in the BIL</comment></member>
+            <member><type>uint32_t</type>               <name>offset</name><comment>Offset of the value in the data block</comment></member>
+            <member><type>size_t</type>                 <name>size</name><comment>Size in bytes of the SpecConstant</comment></member>
         </type>
         <type category="struct" name="VkSpecializationInfo">
-            <member optional="true"><type>uint32_t</type>               <name>mapEntryCount</name></member>                  <!-- Number of entries in the map -->
-            <member len="mapEntryCount" noautovalidity="true">const <type>VkSpecializationMapEntry</type>* <name>pMapEntries</name></member>                  <!-- Array of map entries -->
-            <member optional="true"><type>size_t</type>                 <name>dataSize</name></member>                       <!-- Size in bytes of pData -->
-            <member len="dataSize">const <type>void</type>*            <name>pData</name></member>                          <!-- Pointer to SpecConstant data -->
+            <member optional="true"><type>uint32_t</type>               <name>mapEntryCount</name><comment>Number of entries in the map</comment></member>
+            <member len="mapEntryCount" noautovalidity="true">const <type>VkSpecializationMapEntry</type>* <name>pMapEntries</name><comment>Array of map entries</comment></member>
+            <member optional="true"><type>size_t</type>                 <name>dataSize</name><comment>Size in bytes of pData</comment></member>
+            <member len="dataSize">const <type>void</type>*            <name>pData</name><comment>Pointer to SpecConstant data</comment></member>
         </type>
         <type category="struct" name="VkPipelineShaderStageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkPipelineShaderStageCreateFlags</type>    <name>flags</name></member>             <!-- Reserved -->
-            <member><type>VkShaderStageFlagBits</type>  <name>stage</name></member>                          <!-- Shader stage -->
-            <member><type>VkShaderModule</type>         <name>module</name></member>                         <!-- Module containing entry point -->
-            <member len="null-terminated">const <type>char</type>*            <name>pName</name></member>                          <!-- Null-terminated entry point name -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineShaderStageCreateFlags</type>    <name>flags</name></member>
+            <member><type>VkShaderStageFlagBits</type>  <name>stage</name><comment>Shader stage</comment></member>
+            <member><type>VkShaderModule</type>         <name>module</name><comment>Module containing entry point</comment></member>
+            <member len="null-terminated">const <type>char</type>*            <name>pName</name><comment>Null-terminated entry point name</comment></member>
             <member optional="true">const <type>VkSpecializationInfo</type>* <name>pSpecializationInfo</name></member>
         </type>
         <type category="struct" name="VkComputePipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name></member>                          <!-- Pipeline creation flags -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name><comment>Pipeline creation flags</comment></member>
             <member><type>VkPipelineShaderStageCreateInfo</type> <name>stage</name></member>
-            <member><type>VkPipelineLayout</type>       <name>layout</name></member>                         <!-- Interface layout of the pipeline -->
-            <member noautovalidity="true" optional="true"><type>VkPipeline</type>      <name>basePipelineHandle</name></member>             <!-- If VK_PIPELINE_CREATE_DERIVATIVE_BIT is set and this value is nonzero, it specifies the handle of the base pipeline this is a derivative of -->
-            <member><type>int32_t</type>                <name>basePipelineIndex</name></member>              <!-- If VK_PIPELINE_CREATE_DERIVATIVE_BIT is set and this value is not -1, it specifies an index into pCreateInfos of the base pipeline this is a derivative of -->
+            <member><type>VkPipelineLayout</type>       <name>layout</name><comment>Interface layout of the pipeline</comment></member>
+            <member noautovalidity="true" optional="true"><type>VkPipeline</type>      <name>basePipelineHandle</name><comment>If VK_PIPELINE_CREATE_DERIVATIVE_BIT is set and this value is nonzero, it specifies the handle of the base pipeline this is a derivative of</comment></member>
+            <member><type>int32_t</type>                <name>basePipelineIndex</name><comment>If VK_PIPELINE_CREATE_DERIVATIVE_BIT is set and this value is not -1, it specifies an index into pCreateInfos of the base pipeline this is a derivative of</comment></member>
         </type>
         <type category="struct" name="VkVertexInputBindingDescription">
-            <member><type>uint32_t</type>               <name>binding</name></member>                        <!-- Vertex buffer binding id -->
-            <member><type>uint32_t</type>               <name>stride</name></member>                         <!-- Distance between vertices in bytes (0 = no advancement) -->
-            <member><type>VkVertexInputRate</type>      <name>inputRate</name></member>                      <!-- The rate at which the vertex data is consumed -->
+            <member><type>uint32_t</type>               <name>binding</name><comment>Vertex buffer binding id</comment></member>
+            <member><type>uint32_t</type>               <name>stride</name><comment>Distance between vertices in bytes (0 = no advancement)</comment></member>
+            <member><type>VkVertexInputRate</type>      <name>inputRate</name><comment>The rate at which the vertex data is consumed</comment></member>
         </type>
         <type category="struct" name="VkVertexInputAttributeDescription">
-            <member><type>uint32_t</type>               <name>location</name></member>                       <!-- location of the shader vertex attrib -->
-            <member><type>uint32_t</type>               <name>binding</name></member>                        <!-- Vertex buffer binding id -->
-            <member><type>VkFormat</type>               <name>format</name></member>                         <!-- format of source data -->
-            <member><type>uint32_t</type>               <name>offset</name></member>                         <!-- Offset of first element in bytes from base of vertex -->
+            <member><type>uint32_t</type>               <name>location</name><comment>location of the shader vertex attrib</comment></member>
+            <member><type>uint32_t</type>               <name>binding</name><comment>Vertex buffer binding id</comment></member>
+            <member><type>VkFormat</type>               <name>format</name><comment>format of source data</comment></member>
+            <member><type>uint32_t</type>               <name>offset</name><comment>Offset of first element in bytes from base of vertex</comment></member>
         </type>
         <type category="struct" name="VkPipelineVertexInputStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkPipelineVertexInputStateCreateFlags</type>    <name>flags</name></member>        <!-- Reserved -->
-            <member optional="true"><type>uint32_t</type>               <name>vertexBindingDescriptionCount</name></member>  <!-- number of bindings -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineVertexInputStateCreateFlags</type>    <name>flags</name></member>
+            <member optional="true"><type>uint32_t</type>               <name>vertexBindingDescriptionCount</name><comment>number of bindings</comment></member>
             <member len="vertexBindingDescriptionCount">const <type>VkVertexInputBindingDescription</type>* <name>pVertexBindingDescriptions</name></member>
-            <member optional="true"><type>uint32_t</type>               <name>vertexAttributeDescriptionCount</name></member> <!-- number of attributes -->
+            <member optional="true"><type>uint32_t</type>               <name>vertexAttributeDescriptionCount</name><comment>number of attributes</comment></member>
             <member len="vertexAttributeDescriptionCount">const <type>VkVertexInputAttributeDescription</type>* <name>pVertexAttributeDescriptions</name></member>
         </type>
         <type category="struct" name="VkPipelineInputAssemblyStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkPipelineInputAssemblyStateCreateFlags</type>    <name>flags</name></member>      <!-- Reserved -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineInputAssemblyStateCreateFlags</type>    <name>flags</name></member>
             <member><type>VkPrimitiveTopology</type>    <name>topology</name></member>
             <member><type>VkBool32</type>               <name>primitiveRestartEnable</name></member>
         </type>
         <type category="struct" name="VkPipelineTessellationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkPipelineTessellationStateCreateFlags</type>    <name>flags</name></member>        <!-- Reserved -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineTessellationStateCreateFlags</type>    <name>flags</name></member>
             <member><type>uint32_t</type>               <name>patchControlPoints</name></member>
         </type>
         <type category="struct" name="VkPipelineViewportStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkPipelineViewportStateCreateFlags</type>    <name>flags</name></member>           <!-- Reserved -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineViewportStateCreateFlags</type>    <name>flags</name></member>
             <member><type>uint32_t</type>               <name>viewportCount</name></member>
             <member noautovalidity="true" optional="true" len="viewportCount">const <type>VkViewport</type>*      <name>pViewports</name></member>
             <member><type>uint32_t</type>               <name>scissorCount</name></member>
@@ -897,11 +951,11 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkPipelineRasterizationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member validextensionstructs="VkPipelineRasterizationStateRasterizationOrderAMD">const <type>void</type>* <name>pNext</name></member> <!-- Pointer to next structure -->
-            <member optional="true"><type>VkPipelineRasterizationStateCreateFlags</type>    <name>flags</name></member>             <!-- Reserved -->
+            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineRasterizationStateCreateFlags</type>    <name>flags</name></member>
             <member><type>VkBool32</type>               <name>depthClampEnable</name></member>
             <member><type>VkBool32</type>               <name>rasterizerDiscardEnable</name></member>
-            <member><type>VkPolygonMode</type>          <name>polygonMode</name></member>                       <!-- optional (GL45) -->
+            <member><type>VkPolygonMode</type>          <name>polygonMode</name><comment>optional (GL45)</comment></member>
             <member optional="true"><type>VkCullModeFlags</type>        <name>cullMode</name></member>
             <member><type>VkFrontFace</type>            <name>frontFace</name></member>
             <member><type>VkBool32</type>               <name>depthBiasEnable</name></member>
@@ -912,12 +966,12 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkPipelineMultisampleStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkPipelineMultisampleStateCreateFlags</type>    <name>flags</name></member>        <!-- Reserved -->
-            <member><type>VkSampleCountFlagBits</type>  <name>rasterizationSamples</name></member>           <!-- Number of samples used for rasterization -->
-            <member><type>VkBool32</type>               <name>sampleShadingEnable</name></member>            <!-- optional (GL45) -->
-            <member><type>float</type>                  <name>minSampleShading</name></member>               <!-- optional (GL45) -->
-            <member optional="true" len="latexmath:[$\lceil{\mathit{rasterizationSamples} \over 32}\rceil$]">const <type>VkSampleMask</type>*    <name>pSampleMask</name></member>                    <!-- Array of sampleMask words -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineMultisampleStateCreateFlags</type>    <name>flags</name></member>
+            <member><type>VkSampleCountFlagBits</type>  <name>rasterizationSamples</name><comment>Number of samples used for rasterization</comment></member>
+            <member><type>VkBool32</type>               <name>sampleShadingEnable</name><comment>optional (GL45)</comment></member>
+            <member><type>float</type>                  <name>minSampleShading</name><comment>optional (GL45)</comment></member>
+            <member optional="true" len="latexmath:[\lceil{\mathit{rasterizationSamples} \over 32}\rceil]">const <type>VkSampleMask</type>*    <name>pSampleMask</name><comment>Array of sampleMask words</comment></member>
             <member><type>VkBool32</type>               <name>alphaToCoverageEnable</name></member>
             <member><type>VkBool32</type>               <name>alphaToOneEnable</name></member>
         </type>
@@ -933,18 +987,18 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkPipelineColorBlendStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkPipelineColorBlendStateCreateFlags</type>    <name>flags</name></member>         <!-- Reserved -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineColorBlendStateCreateFlags</type>    <name>flags</name></member>
             <member><type>VkBool32</type>               <name>logicOpEnable</name></member>
             <member noautovalidity="true"><type>VkLogicOp</type>              <name>logicOp</name></member>
-            <member optional="true"><type>uint32_t</type>               <name>attachmentCount</name></member>                <!-- # of pAttachments -->
+            <member optional="true"><type>uint32_t</type>               <name>attachmentCount</name><comment># of pAttachments</comment></member>
             <member len="attachmentCount">const <type>VkPipelineColorBlendAttachmentState</type>* <name>pAttachments</name></member>
             <member><type>float</type>                  <name>blendConstants</name>[4]</member>
         </type>
         <type category="struct" name="VkPipelineDynamicStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkPipelineDynamicStateCreateFlags</type>    <name>flags</name></member>            <!-- Reserved -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineDynamicStateCreateFlags</type>    <name>flags</name></member>
             <member><type>uint32_t</type>               <name>dynamicStateCount</name></member>
             <member len="dynamicStateCount">const <type>VkDynamicState</type>*  <name>pDynamicStates</name></member>
         </type>
@@ -959,12 +1013,12 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkPipelineDepthStencilStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkPipelineDepthStencilStateCreateFlags</type>    <name>flags</name></member>       <!-- Reserved -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineDepthStencilStateCreateFlags</type>    <name>flags</name></member>
             <member><type>VkBool32</type>               <name>depthTestEnable</name></member>
             <member><type>VkBool32</type>               <name>depthWriteEnable</name></member>
             <member><type>VkCompareOp</type>            <name>depthCompareOp</name></member>
-            <member><type>VkBool32</type>               <name>depthBoundsTestEnable</name></member>          <!-- optional (depth_bounds_test) -->
+            <member><type>VkBool32</type>               <name>depthBoundsTestEnable</name><comment>optional (depth_bounds_test)</comment></member>
             <member><type>VkBool32</type>               <name>stencilTestEnable</name></member>
             <member><type>VkStencilOpState</type>       <name>front</name></member>
             <member><type>VkStencilOpState</type>       <name>back</name></member>
@@ -973,10 +1027,10 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkGraphicsPipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name></member>                          <!-- Pipeline creation flags -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name><comment>Pipeline creation flags</comment></member>
             <member><type>uint32_t</type>               <name>stageCount</name></member>
-            <member len="stageCount">const <type>VkPipelineShaderStageCreateInfo</type>* <name>pStages</name></member>        <!-- One entry for each active shader stage -->
+            <member len="stageCount">const <type>VkPipelineShaderStageCreateInfo</type>* <name>pStages</name><comment>One entry for each active shader stage</comment></member>
             <member>const <type>VkPipelineVertexInputStateCreateInfo</type>* <name>pVertexInputState</name></member>
             <member>const <type>VkPipelineInputAssemblyStateCreateInfo</type>* <name>pInputAssemblyState</name></member>
             <member noautovalidity="true" optional="true">const <type>VkPipelineTessellationStateCreateInfo</type>* <name>pTessellationState</name></member>
@@ -986,40 +1040,40 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member noautovalidity="true" optional="true">const <type>VkPipelineDepthStencilStateCreateInfo</type>* <name>pDepthStencilState</name></member>
             <member noautovalidity="true" optional="true">const <type>VkPipelineColorBlendStateCreateInfo</type>* <name>pColorBlendState</name></member>
             <member optional="true">const <type>VkPipelineDynamicStateCreateInfo</type>* <name>pDynamicState</name></member>
-            <member><type>VkPipelineLayout</type>       <name>layout</name></member>                         <!-- Interface layout of the pipeline -->
+            <member><type>VkPipelineLayout</type>       <name>layout</name><comment>Interface layout of the pipeline</comment></member>
             <member><type>VkRenderPass</type>           <name>renderPass</name></member>
             <member><type>uint32_t</type>               <name>subpass</name></member>
-            <member noautovalidity="true" optional="true"><type>VkPipeline</type>      <name>basePipelineHandle</name></member>             <!-- If VK_PIPELINE_CREATE_DERIVATIVE_BIT is set and this value is nonzero, it specifies the handle of the base pipeline this is a derivative of -->
-            <member><type>int32_t</type>                <name>basePipelineIndex</name></member>              <!-- If VK_PIPELINE_CREATE_DERIVATIVE_BIT is set and this value is not -1, it specifies an index into pCreateInfos of the base pipeline this is a derivative of -->
+            <member noautovalidity="true" optional="true"><type>VkPipeline</type>      <name>basePipelineHandle</name><comment>If VK_PIPELINE_CREATE_DERIVATIVE_BIT is set and this value is nonzero, it specifies the handle of the base pipeline this is a derivative of</comment></member>
+            <member><type>int32_t</type>                <name>basePipelineIndex</name><comment>If VK_PIPELINE_CREATE_DERIVATIVE_BIT is set and this value is not -1, it specifies an index into pCreateInfos of the base pipeline this is a derivative of</comment></member>
         </type>
         <type category="struct" name="VkPipelineCacheCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkPipelineCacheCreateFlags</type>    <name>flags</name></member>                   <!-- Reserved -->
-            <member optional="true"><type>size_t</type>                 <name>initialDataSize</name></member>                <!-- Size of initial data to populate cache, in bytes -->
-            <member len="initialDataSize">const <type>void</type>*            <name>pInitialData</name></member>                    <!-- Initial data to populate cache -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineCacheCreateFlags</type>    <name>flags</name></member>
+            <member optional="true"><type>size_t</type>                 <name>initialDataSize</name><comment>Size of initial data to populate cache, in bytes</comment></member>
+            <member len="initialDataSize">const <type>void</type>*            <name>pInitialData</name><comment>Initial data to populate cache</comment></member>
         </type>
         <type category="struct" name="VkPushConstantRange">
-            <member><type>VkShaderStageFlags</type>     <name>stageFlags</name></member>                     <!-- Which stages use the range -->
-            <member><type>uint32_t</type>               <name>offset</name></member>                         <!-- Start of the range, in bytes -->
-            <member><type>uint32_t</type>               <name>size</name></member>                           <!-- Size of the range, in bytes -->
+            <member><type>VkShaderStageFlags</type>     <name>stageFlags</name><comment>Which stages use the range</comment></member>
+            <member><type>uint32_t</type>               <name>offset</name><comment>Start of the range, in bytes</comment></member>
+            <member><type>uint32_t</type>               <name>size</name><comment>Size of the range, in bytes</comment></member>
         </type>
         <type category="struct" name="VkPipelineLayoutCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkPipelineLayoutCreateFlags</type>    <name>flags</name></member>                  <!-- Reserved -->
-            <member optional="true"><type>uint32_t</type>               <name>setLayoutCount</name></member>                 <!-- Number of descriptor sets interfaced by the pipeline -->
-            <member len="setLayoutCount">const <type>VkDescriptorSetLayout</type>* <name>pSetLayouts</name></member>              <!-- Array of setCount number of descriptor set layout objects defining the layout of the -->
-            <member optional="true"><type>uint32_t</type>               <name>pushConstantRangeCount</name></member>         <!-- Number of push-constant ranges used by the pipeline -->
-            <member len="pushConstantRangeCount">const <type>VkPushConstantRange</type>* <name>pPushConstantRanges</name></member>        <!-- Array of pushConstantRangeCount number of ranges used by various shader stages -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineLayoutCreateFlags</type>    <name>flags</name></member>
+            <member optional="true"><type>uint32_t</type>               <name>setLayoutCount</name><comment>Number of descriptor sets interfaced by the pipeline</comment></member>
+            <member len="setLayoutCount">const <type>VkDescriptorSetLayout</type>* <name>pSetLayouts</name><comment>Array of setCount number of descriptor set layout objects defining the layout of the</comment></member>
+            <member optional="true"><type>uint32_t</type>               <name>pushConstantRangeCount</name><comment>Number of push-constant ranges used by the pipeline</comment></member>
+            <member len="pushConstantRangeCount">const <type>VkPushConstantRange</type>* <name>pPushConstantRanges</name><comment>Array of pushConstantRangeCount number of ranges used by various shader stages</comment></member>
         </type>
         <type category="struct" name="VkSamplerCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkSamplerCreateFlags</type>   <name>flags</name></member>                          <!-- Reserved -->
-            <member><type>VkFilter</type>               <name>magFilter</name></member>                      <!-- Filter mode for magnification -->
-            <member><type>VkFilter</type>               <name>minFilter</name></member>                      <!-- Filter mode for minifiation -->
-            <member><type>VkSamplerMipmapMode</type>    <name>mipmapMode</name></member>                     <!-- Mipmap selection mode -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkSamplerCreateFlags</type>   <name>flags</name></member>
+            <member><type>VkFilter</type>               <name>magFilter</name><comment>Filter mode for magnification</comment></member>
+            <member><type>VkFilter</type>               <name>minFilter</name><comment>Filter mode for minifiation</comment></member>
+            <member><type>VkSamplerMipmapMode</type>    <name>mipmapMode</name><comment>Mipmap selection mode</comment></member>
             <member><type>VkSamplerAddressMode</type>   <name>addressModeU</name></member>
             <member><type>VkSamplerAddressMode</type>   <name>addressModeV</name></member>
             <member><type>VkSamplerAddressMode</type>   <name>addressModeW</name></member>
@@ -1035,36 +1089,36 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkCommandPoolCreateInfo">
             <member values="VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkCommandPoolCreateFlags</type>   <name>flags</name></member>      <!-- Command pool creation flags -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkCommandPoolCreateFlags</type>   <name>flags</name><comment>Command pool creation flags</comment></member>
             <member><type>uint32_t</type>               <name>queueFamilyIndex</name></member>
         </type>
         <type category="struct" name="VkCommandBufferAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkCommandPool</type>          <name>commandPool</name></member>
             <member><type>VkCommandBufferLevel</type>   <name>level</name></member>
             <member><type>uint32_t</type>               <name>commandBufferCount</name></member>
         </type>
         <type category="struct" name="VkCommandBufferInheritanceInfo">
             <member values="VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true" noautovalidity="true"><type>VkRenderPass</type>    <name>renderPass</name></member>                     <!-- Render pass for secondary command buffers -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true" noautovalidity="true"><type>VkRenderPass</type>    <name>renderPass</name><comment>Render pass for secondary command buffers</comment></member>
             <member><type>uint32_t</type>               <name>subpass</name></member>
-            <member optional="true" noautovalidity="true"><type>VkFramebuffer</type>   <name>framebuffer</name></member>                    <!-- Framebuffer for secondary command buffers -->
-            <member><type>VkBool32</type>               <name>occlusionQueryEnable</name></member>           <!-- Whether this secondary command buffer may be executed during an occlusion query -->
-            <member optional="true" noautovalidity="true"><type>VkQueryControlFlags</type>    <name>queryFlags</name></member>                     <!-- Query flags used by this secondary command buffer, if executed during an occlusion query -->
-            <member optional="true" noautovalidity="true"><type>VkQueryPipelineStatisticFlags</type> <name>pipelineStatistics</name></member>      <!-- Pipeline statistics that may be counted for this secondary command buffer -->
+            <member optional="true" noautovalidity="true"><type>VkFramebuffer</type>   <name>framebuffer</name><comment>Framebuffer for secondary command buffers</comment></member>
+            <member><type>VkBool32</type>               <name>occlusionQueryEnable</name><comment>Whether this secondary command buffer may be executed during an occlusion query</comment></member>
+            <member optional="true" noautovalidity="true"><type>VkQueryControlFlags</type>    <name>queryFlags</name><comment>Query flags used by this secondary command buffer, if executed during an occlusion query</comment></member>
+            <member optional="true" noautovalidity="true"><type>VkQueryPipelineStatisticFlags</type> <name>pipelineStatistics</name><comment>Pipeline statistics that may be counted for this secondary command buffer</comment></member>
         </type>
         <type category="struct" name="VkCommandBufferBeginInfo">
             <member values="VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkCommandBufferUsageFlags</type>  <name>flags</name></member>                          <!-- Command buffer usage flags -->
-            <member optional="true" noautovalidity="true">const <type>VkCommandBufferInheritanceInfo</type>*       <name>pInheritanceInfo</name></member>                          <!-- Pointer to inheritance info for secondary command buffers -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkCommandBufferUsageFlags</type>  <name>flags</name><comment>Command buffer usage flags</comment></member>
+            <member optional="true" noautovalidity="true">const <type>VkCommandBufferInheritanceInfo</type>*       <name>pInheritanceInfo</name><comment>Pointer to inheritance info for secondary command buffers</comment></member>
         </type>
         <type category="struct" name="VkRenderPassBeginInfo">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkRenderPass</type>           <name>renderPass</name></member>
             <member><type>VkFramebuffer</type>          <name>framebuffer</name></member>
             <member><type>VkRect2D</type>               <name>renderArea</name></member>
@@ -1093,10 +1147,10 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member optional="true"><type>VkAttachmentDescriptionFlags</type> <name>flags</name></member>
             <member><type>VkFormat</type>               <name>format</name></member>
             <member><type>VkSampleCountFlagBits</type>  <name>samples</name></member>
-            <member><type>VkAttachmentLoadOp</type>     <name>loadOp</name></member>                         <!-- Load operation for color or depth data -->
-            <member><type>VkAttachmentStoreOp</type>    <name>storeOp</name></member>                        <!-- Store operation for color or depth data -->
-            <member><type>VkAttachmentLoadOp</type>     <name>stencilLoadOp</name></member>                  <!-- Load operation for stencil data -->
-            <member><type>VkAttachmentStoreOp</type>    <name>stencilStoreOp</name></member>                 <!-- Store operation for stencil data -->
+            <member><type>VkAttachmentLoadOp</type>     <name>loadOp</name><comment>Load operation for color or depth data</comment></member>
+            <member><type>VkAttachmentStoreOp</type>    <name>storeOp</name><comment>Store operation for color or depth data</comment></member>
+            <member><type>VkAttachmentLoadOp</type>     <name>stencilLoadOp</name><comment>Load operation for stencil data</comment></member>
+            <member><type>VkAttachmentStoreOp</type>    <name>stencilStoreOp</name><comment>Store operation for stencil data</comment></member>
             <member><type>VkImageLayout</type>          <name>initialLayout</name></member>
             <member><type>VkImageLayout</type>          <name>finalLayout</name></member>
         </type>
@@ -1106,7 +1160,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkSubpassDescription">
             <member optional="true"><type>VkSubpassDescriptionFlags</type> <name>flags</name></member>
-            <member><type>VkPipelineBindPoint</type>    <name>pipelineBindPoint</name></member>              <!-- Must be VK_PIPELINE_BIND_POINT_GRAPHICS for now -->
+            <member><type>VkPipelineBindPoint</type>    <name>pipelineBindPoint</name><comment>Must be VK_PIPELINE_BIND_POINT_GRAPHICS for now</comment></member>
             <member optional="true"><type>uint32_t</type>               <name>inputAttachmentCount</name></member>
             <member len="inputAttachmentCount">const <type>VkAttachmentReference</type>* <name>pInputAttachments</name></member>
             <member optional="true"><type>uint32_t</type>               <name>colorAttachmentCount</name></member>
@@ -1121,14 +1175,14 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member><type>uint32_t</type>               <name>dstSubpass</name></member>
             <member><type>VkPipelineStageFlags</type>   <name>srcStageMask</name></member>
             <member><type>VkPipelineStageFlags</type>   <name>dstStageMask</name></member>
-            <member optional="true"><type>VkAccessFlags</type>          <name>srcAccessMask</name></member>                  <!-- Memory accesses from the source of the dependency to synchronize -->
-            <member optional="true"><type>VkAccessFlags</type>          <name>dstAccessMask</name></member>                  <!-- Memory accesses from the destination of the dependency to synchronize -->
+            <member optional="true"><type>VkAccessFlags</type>          <name>srcAccessMask</name><comment>Memory accesses from the source of the dependency to synchronize</comment></member>
+            <member optional="true"><type>VkAccessFlags</type>          <name>dstAccessMask</name><comment>Memory accesses from the destination of the dependency to synchronize</comment></member>
             <member optional="true"><type>VkDependencyFlags</type>      <name>dependencyFlags</name></member>
         </type>
         <type category="struct" name="VkRenderPassCreateInfo">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkRenderPassCreateFlags</type>    <name>flags</name></member>                      <!-- Reserved -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkRenderPassCreateFlags</type>    <name>flags</name></member>
             <member optional="true"><type>uint32_t</type>   <name>attachmentCount</name></member>
             <member len="attachmentCount">const <type>VkAttachmentDescription</type>* <name>pAttachments</name></member>
             <member><type>uint32_t</type>               <name>subpassCount</name></member>
@@ -1138,212 +1192,212 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkEventCreateInfo">
             <member values="VK_STRUCTURE_TYPE_EVENT_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkEventCreateFlags</type>     <name>flags</name></member>                          <!-- Event creation flags -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkEventCreateFlags</type>     <name>flags</name><comment>Event creation flags</comment></member>
         </type>
         <type category="struct" name="VkFenceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_FENCE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkFenceCreateFlags</type>     <name>flags</name></member>                          <!-- Fence creation flags -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkFenceCreateFlags</type>     <name>flags</name><comment>Fence creation flags</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFeatures">
-            <member><type>VkBool32</type>               <name>robustBufferAccess</name></member>                <!-- out of bounds buffer accesses are well defined -->
-            <member><type>VkBool32</type>               <name>fullDrawIndexUint32</name></member>               <!-- full 32-bit range of indices for indexed draw calls -->
-            <member><type>VkBool32</type>               <name>imageCubeArray</name></member>                    <!-- image views which are arrays of cube maps -->
-            <member><type>VkBool32</type>               <name>independentBlend</name></member>                  <!-- blending operations are controlled per-attachment -->
-            <member><type>VkBool32</type>               <name>geometryShader</name></member>                    <!-- geometry stage -->
-            <member><type>VkBool32</type>               <name>tessellationShader</name></member>                <!-- tessellation control and evaluation stage -->
-            <member><type>VkBool32</type>               <name>sampleRateShading</name></member>                 <!-- per-sample shading and interpolation -->
-            <member><type>VkBool32</type>               <name>dualSrcBlend</name></member>                      <!-- blend operations which take two sources -->
-            <member><type>VkBool32</type>               <name>logicOp</name></member>                           <!-- logic operations -->
-            <member><type>VkBool32</type>               <name>multiDrawIndirect</name></member>                 <!-- multi draw indirect -->
-            <member><type>VkBool32</type>               <name>drawIndirectFirstInstance</name></member>         <!-- indirect draws can use non-zero firstInstance -->
-            <member><type>VkBool32</type>               <name>depthClamp</name></member>                        <!-- depth clamping -->
-            <member><type>VkBool32</type>               <name>depthBiasClamp</name></member>                    <!-- depth bias clamping -->
-            <member><type>VkBool32</type>               <name>fillModeNonSolid</name></member>                  <!-- point and wireframe fill modes -->
-            <member><type>VkBool32</type>               <name>depthBounds</name></member>                       <!-- depth bounds test -->
-            <member><type>VkBool32</type>               <name>wideLines</name></member>                         <!-- lines with width greater than 1 -->
-            <member><type>VkBool32</type>               <name>largePoints</name></member>                       <!-- points with size greater than 1 -->
-            <member><type>VkBool32</type>               <name>alphaToOne</name></member>                        <!-- the fragment alpha component can be forced to maximum representable alpha value -->
-            <member><type>VkBool32</type>               <name>multiViewport</name></member>                     <!-- viewport arrays -->
-            <member><type>VkBool32</type>               <name>samplerAnisotropy</name></member>                 <!-- anisotropic sampler filtering -->
-            <member><type>VkBool32</type>               <name>textureCompressionETC2</name></member>            <!-- ETC texture compression formats -->
-            <member><type>VkBool32</type>               <name>textureCompressionASTC_LDR</name></member>        <!-- ASTC LDR texture compression formats -->
-            <member><type>VkBool32</type>               <name>textureCompressionBC</name></member>              <!-- BC1-7 texture compressed formats -->
-            <member><type>VkBool32</type>               <name>occlusionQueryPrecise</name></member>             <!-- precise occlusion queries returning actual sample counts -->
-            <member><type>VkBool32</type>               <name>pipelineStatisticsQuery</name></member>           <!-- pipeline statistics query -->
-            <member><type>VkBool32</type>               <name>vertexPipelineStoresAndAtomics</name></member>    <!-- stores and atomic ops on storage buffers and images are supported in vertex, tessellation, and geometry stages -->
-            <member><type>VkBool32</type>               <name>fragmentStoresAndAtomics</name></member>          <!-- stores and atomic ops on storage buffers and images are supported in the fragment stage -->
-            <member><type>VkBool32</type>               <name>shaderTessellationAndGeometryPointSize</name></member><!-- tessellation and geometry stages can export point size -->
-            <member><type>VkBool32</type>               <name>shaderImageGatherExtended</name></member>         <!-- image gather with run-time values and independent offsets -->
-            <member><type>VkBool32</type>               <name>shaderStorageImageExtendedFormats</name></member> <!-- the extended set of formats can be used for storage images -->
-            <member><type>VkBool32</type>               <name>shaderStorageImageMultisample</name></member>     <!-- multisample images can be used for storage images -->
-            <member><type>VkBool32</type>               <name>shaderStorageImageReadWithoutFormat</name></member>       <!-- read from storage image does not require format qualifier -->
-            <member><type>VkBool32</type>               <name>shaderStorageImageWriteWithoutFormat</name></member>      <!-- write to storage image does not require format qualifier -->
-            <member><type>VkBool32</type>               <name>shaderUniformBufferArrayDynamicIndexing</name></member>   <!-- arrays of uniform buffers can be accessed with dynamically uniform indices -->
-            <member><type>VkBool32</type>               <name>shaderSampledImageArrayDynamicIndexing</name></member>    <!-- arrays of sampled images can be accessed with dynamically uniform indices -->
-            <member><type>VkBool32</type>               <name>shaderStorageBufferArrayDynamicIndexing</name></member>   <!-- arrays of storage buffers can be accessed with dynamically uniform indices -->
-            <member><type>VkBool32</type>               <name>shaderStorageImageArrayDynamicIndexing</name></member>    <!-- arrays of storage images can be accessed with dynamically uniform indices -->
-            <member><type>VkBool32</type>               <name>shaderClipDistance</name></member>                <!-- clip distance in shaders -->
-            <member><type>VkBool32</type>               <name>shaderCullDistance</name></member>                <!-- cull distance in shaders -->
-            <member><type>VkBool32</type>               <name>shaderFloat64</name></member>                     <!-- 64-bit floats (doubles) in shaders -->
-            <member><type>VkBool32</type>               <name>shaderInt64</name></member>                       <!-- 64-bit integers in shaders -->
-            <member><type>VkBool32</type>               <name>shaderInt16</name></member>                       <!-- 16-bit integers in shaders -->
-            <member><type>VkBool32</type>               <name>shaderResourceResidency</name></member>           <!-- shader can use texture operations that return resource residency information (requires sparseNonResident support) -->
-            <member><type>VkBool32</type>               <name>shaderResourceMinLod</name></member>              <!-- shader can use texture operations that specify minimum resource level of detail -->
-            <member><type>VkBool32</type>               <name>sparseBinding</name></member>                     <!-- Sparse resources support: Resource memory can be managed at opaque page level rather than object level -->
-            <member><type>VkBool32</type>               <name>sparseResidencyBuffer</name></member>             <!-- Sparse resources support: GPU can access partially resident buffers  -->
-            <member><type>VkBool32</type>               <name>sparseResidencyImage2D</name></member>            <!-- Sparse resources support: GPU can access partially resident 2D (non-MSAA non-depth/stencil) images  -->
-            <member><type>VkBool32</type>               <name>sparseResidencyImage3D</name></member>            <!-- Sparse resources support: GPU can access partially resident 3D images  -->
-            <member><type>VkBool32</type>               <name>sparseResidency2Samples</name></member>           <!-- Sparse resources support: GPU can access partially resident MSAA 2D images with 2 samples -->
-            <member><type>VkBool32</type>               <name>sparseResidency4Samples</name></member>           <!-- Sparse resources support: GPU can access partially resident MSAA 2D images with 4 samples -->
-            <member><type>VkBool32</type>               <name>sparseResidency8Samples</name></member>           <!-- Sparse resources support: GPU can access partially resident MSAA 2D images with 8 samples -->
-            <member><type>VkBool32</type>               <name>sparseResidency16Samples</name></member>          <!-- Sparse resources support: GPU can access partially resident MSAA 2D images with 16 samples -->
-            <member><type>VkBool32</type>               <name>sparseResidencyAliased</name></member>            <!-- Sparse resources support: GPU can correctly access data aliased into multiple locations (opt-in) -->
-            <member><type>VkBool32</type>               <name>variableMultisampleRate</name></member>           <!-- multisample rate must be the same for all pipelines in a subpass -->
-            <member><type>VkBool32</type>               <name>inheritedQueries</name></member>                  <!-- Queries may be inherited from primary to secondary command buffers -->
+            <member><type>VkBool32</type>               <name>robustBufferAccess</name><comment>out of bounds buffer accesses are well defined</comment></member>
+            <member><type>VkBool32</type>               <name>fullDrawIndexUint32</name><comment>full 32-bit range of indices for indexed draw calls</comment></member>
+            <member><type>VkBool32</type>               <name>imageCubeArray</name><comment>image views which are arrays of cube maps</comment></member>
+            <member><type>VkBool32</type>               <name>independentBlend</name><comment>blending operations are controlled per-attachment</comment></member>
+            <member><type>VkBool32</type>               <name>geometryShader</name><comment>geometry stage</comment></member>
+            <member><type>VkBool32</type>               <name>tessellationShader</name><comment>tessellation control and evaluation stage</comment></member>
+            <member><type>VkBool32</type>               <name>sampleRateShading</name><comment>per-sample shading and interpolation</comment></member>
+            <member><type>VkBool32</type>               <name>dualSrcBlend</name><comment>blend operations which take two sources</comment></member>
+            <member><type>VkBool32</type>               <name>logicOp</name><comment>logic operations</comment></member>
+            <member><type>VkBool32</type>               <name>multiDrawIndirect</name><comment>multi draw indirect</comment></member>
+            <member><type>VkBool32</type>               <name>drawIndirectFirstInstance</name><comment>indirect draws can use non-zero firstInstance</comment></member>
+            <member><type>VkBool32</type>               <name>depthClamp</name><comment>depth clamping</comment></member>
+            <member><type>VkBool32</type>               <name>depthBiasClamp</name><comment>depth bias clamping</comment></member>
+            <member><type>VkBool32</type>               <name>fillModeNonSolid</name><comment>point and wireframe fill modes</comment></member>
+            <member><type>VkBool32</type>               <name>depthBounds</name><comment>depth bounds test</comment></member>
+            <member><type>VkBool32</type>               <name>wideLines</name><comment>lines with width greater than 1</comment></member>
+            <member><type>VkBool32</type>               <name>largePoints</name><comment>points with size greater than 1</comment></member>
+            <member><type>VkBool32</type>               <name>alphaToOne</name><comment>the fragment alpha component can be forced to maximum representable alpha value</comment></member>
+            <member><type>VkBool32</type>               <name>multiViewport</name><comment>viewport arrays</comment></member>
+            <member><type>VkBool32</type>               <name>samplerAnisotropy</name><comment>anisotropic sampler filtering</comment></member>
+            <member><type>VkBool32</type>               <name>textureCompressionETC2</name><comment>ETC texture compression formats</comment></member>
+            <member><type>VkBool32</type>               <name>textureCompressionASTC_LDR</name><comment>ASTC LDR texture compression formats</comment></member>
+            <member><type>VkBool32</type>               <name>textureCompressionBC</name><comment>BC1-7 texture compressed formats</comment></member>
+            <member><type>VkBool32</type>               <name>occlusionQueryPrecise</name><comment>precise occlusion queries returning actual sample counts</comment></member>
+            <member><type>VkBool32</type>               <name>pipelineStatisticsQuery</name><comment>pipeline statistics query</comment></member>
+            <member><type>VkBool32</type>               <name>vertexPipelineStoresAndAtomics</name><comment>stores and atomic ops on storage buffers and images are supported in vertex, tessellation, and geometry stages</comment></member>
+            <member><type>VkBool32</type>               <name>fragmentStoresAndAtomics</name><comment>stores and atomic ops on storage buffers and images are supported in the fragment stage</comment></member>
+            <member><type>VkBool32</type>               <name>shaderTessellationAndGeometryPointSize</name><comment>tessellation and geometry stages can export point size</comment></member>
+            <member><type>VkBool32</type>               <name>shaderImageGatherExtended</name><comment>image gather with run-time values and independent offsets</comment></member>
+            <member><type>VkBool32</type>               <name>shaderStorageImageExtendedFormats</name><comment>the extended set of formats can be used for storage images</comment></member>
+            <member><type>VkBool32</type>               <name>shaderStorageImageMultisample</name><comment>multisample images can be used for storage images</comment></member>
+            <member><type>VkBool32</type>               <name>shaderStorageImageReadWithoutFormat</name><comment>read from storage image does not require format qualifier</comment></member>
+            <member><type>VkBool32</type>               <name>shaderStorageImageWriteWithoutFormat</name><comment>write to storage image does not require format qualifier</comment></member>
+            <member><type>VkBool32</type>               <name>shaderUniformBufferArrayDynamicIndexing</name><comment>arrays of uniform buffers can be accessed with dynamically uniform indices</comment></member>
+            <member><type>VkBool32</type>               <name>shaderSampledImageArrayDynamicIndexing</name><comment>arrays of sampled images can be accessed with dynamically uniform indices</comment></member>
+            <member><type>VkBool32</type>               <name>shaderStorageBufferArrayDynamicIndexing</name><comment>arrays of storage buffers can be accessed with dynamically uniform indices</comment></member>
+            <member><type>VkBool32</type>               <name>shaderStorageImageArrayDynamicIndexing</name><comment>arrays of storage images can be accessed with dynamically uniform indices</comment></member>
+            <member><type>VkBool32</type>               <name>shaderClipDistance</name><comment>clip distance in shaders</comment></member>
+            <member><type>VkBool32</type>               <name>shaderCullDistance</name><comment>cull distance in shaders</comment></member>
+            <member><type>VkBool32</type>               <name>shaderFloat64</name><comment>64-bit floats (doubles) in shaders</comment></member>
+            <member><type>VkBool32</type>               <name>shaderInt64</name><comment>64-bit integers in shaders</comment></member>
+            <member><type>VkBool32</type>               <name>shaderInt16</name><comment>16-bit integers in shaders</comment></member>
+            <member><type>VkBool32</type>               <name>shaderResourceResidency</name><comment>shader can use texture operations that return resource residency information (requires sparseNonResident support)</comment></member>
+            <member><type>VkBool32</type>               <name>shaderResourceMinLod</name><comment>shader can use texture operations that specify minimum resource level of detail</comment></member>
+            <member><type>VkBool32</type>               <name>sparseBinding</name><comment>Sparse resources support: Resource memory can be managed at opaque page level rather than object level</comment></member>
+            <member><type>VkBool32</type>               <name>sparseResidencyBuffer</name><comment>Sparse resources support: GPU can access partially resident buffers </comment></member>
+            <member><type>VkBool32</type>               <name>sparseResidencyImage2D</name><comment>Sparse resources support: GPU can access partially resident 2D (non-MSAA non-depth/stencil) images </comment></member>
+            <member><type>VkBool32</type>               <name>sparseResidencyImage3D</name><comment>Sparse resources support: GPU can access partially resident 3D images </comment></member>
+            <member><type>VkBool32</type>               <name>sparseResidency2Samples</name><comment>Sparse resources support: GPU can access partially resident MSAA 2D images with 2 samples</comment></member>
+            <member><type>VkBool32</type>               <name>sparseResidency4Samples</name><comment>Sparse resources support: GPU can access partially resident MSAA 2D images with 4 samples</comment></member>
+            <member><type>VkBool32</type>               <name>sparseResidency8Samples</name><comment>Sparse resources support: GPU can access partially resident MSAA 2D images with 8 samples</comment></member>
+            <member><type>VkBool32</type>               <name>sparseResidency16Samples</name><comment>Sparse resources support: GPU can access partially resident MSAA 2D images with 16 samples</comment></member>
+            <member><type>VkBool32</type>               <name>sparseResidencyAliased</name><comment>Sparse resources support: GPU can correctly access data aliased into multiple locations (opt-in)</comment></member>
+            <member><type>VkBool32</type>               <name>variableMultisampleRate</name><comment>multisample rate must be the same for all pipelines in a subpass</comment></member>
+            <member><type>VkBool32</type>               <name>inheritedQueries</name><comment>Queries may be inherited from primary to secondary command buffers</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSparseProperties" returnedonly="true">
-            <member><type>VkBool32</type>               <name>residencyStandard2DBlockShape</name></member> <!-- Sparse resources support: GPU will access all 2D (single sample) sparse resources using the standard sparse image block shapes (based on pixel format) -->
-            <member><type>VkBool32</type>               <name>residencyStandard2DMultisampleBlockShape</name></member> <!-- Sparse resources support: GPU will access all 2D (multisample) sparse resources using the standard sparse image block shapes (based on pixel format) -->
-            <member><type>VkBool32</type>               <name>residencyStandard3DBlockShape</name></member> <!-- Sparse resources support: GPU will access all 3D sparse resources using the standard sparse image block shapes (based on pixel format) -->
-            <member><type>VkBool32</type>               <name>residencyAlignedMipSize</name></member>     <!-- Sparse resources support: Images with mip level dimensions that are NOT a multiple of the sparse image block dimensions will be placed in the mip tail -->
-            <member><type>VkBool32</type>               <name>residencyNonResidentStrict</name></member>  <!-- Sparse resources support: GPU can consistently access non-resident regions of a resource, all reads return as if data is 0, writes are discarded -->
+            <member><type>VkBool32</type>               <name>residencyStandard2DBlockShape</name><comment>Sparse resources support: GPU will access all 2D (single sample) sparse resources using the standard sparse image block shapes (based on pixel format)</comment></member>
+            <member><type>VkBool32</type>               <name>residencyStandard2DMultisampleBlockShape</name><comment>Sparse resources support: GPU will access all 2D (multisample) sparse resources using the standard sparse image block shapes (based on pixel format)</comment></member>
+            <member><type>VkBool32</type>               <name>residencyStandard3DBlockShape</name><comment>Sparse resources support: GPU will access all 3D sparse resources using the standard sparse image block shapes (based on pixel format)</comment></member>
+            <member><type>VkBool32</type>               <name>residencyAlignedMipSize</name><comment>Sparse resources support: Images with mip level dimensions that are NOT a multiple of the sparse image block dimensions will be placed in the mip tail</comment></member>
+            <member><type>VkBool32</type>               <name>residencyNonResidentStrict</name><comment>Sparse resources support: GPU can consistently access non-resident regions of a resource, all reads return as if data is 0, writes are discarded</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceLimits" returnedonly="true">
-                <!-- resource maximum sizes -->
-            <member><type>uint32_t</type>               <name>maxImageDimension1D</name></member>               <!-- max 1D image dimension -->
-            <member><type>uint32_t</type>               <name>maxImageDimension2D</name></member>               <!-- max 2D image dimension -->
-            <member><type>uint32_t</type>               <name>maxImageDimension3D</name></member>               <!-- max 3D image dimension -->
-            <member><type>uint32_t</type>               <name>maxImageDimensionCube</name></member>             <!-- max cubemap image dimension -->
-            <member><type>uint32_t</type>               <name>maxImageArrayLayers</name></member>               <!-- max layers for image arrays -->
-            <member><type>uint32_t</type>               <name>maxTexelBufferElements</name></member>            <!-- max texel buffer size (fstexels) -->
-            <member><type>uint32_t</type>               <name>maxUniformBufferRange</name></member>             <!-- max uniform buffer range (bytes) -->
-            <member><type>uint32_t</type>               <name>maxStorageBufferRange</name></member>             <!-- max storage buffer range (bytes) -->
-            <member><type>uint32_t</type>               <name>maxPushConstantsSize</name></member>              <!-- max size of the push constants pool (bytes) -->
-                <!-- memory limits -->
-            <member><type>uint32_t</type>               <name>maxMemoryAllocationCount</name></member>          <!-- max number of device memory allocations supported -->
-            <member><type>uint32_t</type>               <name>maxSamplerAllocationCount</name></member>         <!-- max number of samplers that can be allocated on a device -->
-            <member><type>VkDeviceSize</type>           <name>bufferImageGranularity</name></member>            <!-- Granularity (in bytes) at which buffers and images can be bound to adjacent memory for simultaneous usage -->
-            <member><type>VkDeviceSize</type>           <name>sparseAddressSpaceSize</name></member>            <!-- Total address space available for sparse allocations (bytes) -->
-                <!-- descriptor set limits -->
-            <member><type>uint32_t</type>               <name>maxBoundDescriptorSets</name></member>                <!-- max number of descriptors sets that can be bound to a pipeline -->
-            <member><type>uint32_t</type>               <name>maxPerStageDescriptorSamplers</name></member>         <!-- max number of samplers allowed per-stage in a descriptor set -->
-            <member><type>uint32_t</type>               <name>maxPerStageDescriptorUniformBuffers</name></member>   <!-- max number of uniform buffers allowed per-stage in a descriptor set -->
-            <member><type>uint32_t</type>               <name>maxPerStageDescriptorStorageBuffers</name></member>   <!-- max number of storage buffers allowed per-stage in a descriptor set -->
-            <member><type>uint32_t</type>               <name>maxPerStageDescriptorSampledImages</name></member>    <!-- max number of sampled images allowed per-stage in a descriptor set -->
-            <member><type>uint32_t</type>               <name>maxPerStageDescriptorStorageImages</name></member>    <!-- max number of storage images allowed per-stage in a descriptor set -->
-            <member><type>uint32_t</type>               <name>maxPerStageDescriptorInputAttachments</name></member> <!-- max number of input attachments allowed per-stage in a descriptor set -->
-            <member><type>uint32_t</type>               <name>maxPerStageResources</name></member>                  <!-- max number of resources allowed by a single stage -->
-            <member><type>uint32_t</type>               <name>maxDescriptorSetSamplers</name></member>              <!-- max number of samplers allowed in all stages in a descriptor set -->
-            <member><type>uint32_t</type>               <name>maxDescriptorSetUniformBuffers</name></member>        <!-- max number of uniform buffers allowed in all stages in a descriptor set -->
-            <member><type>uint32_t</type>               <name>maxDescriptorSetUniformBuffersDynamic</name></member> <!-- max number of dynamic uniform buffers allowed in all stages in a descriptor set -->
-            <member><type>uint32_t</type>               <name>maxDescriptorSetStorageBuffers</name></member>        <!-- max number of storage buffers allowed in all stages in a descriptor set -->
-            <member><type>uint32_t</type>               <name>maxDescriptorSetStorageBuffersDynamic</name></member> <!-- max number of dynamic storage buffers allowed in all stages in a descriptor set -->
-            <member><type>uint32_t</type>               <name>maxDescriptorSetSampledImages</name></member>         <!-- max number of sampled images allowed in all stages in a descriptor set -->
-            <member><type>uint32_t</type>               <name>maxDescriptorSetStorageImages</name></member>         <!-- max number of storage images allowed in all stages in a descriptor set -->
-            <member><type>uint32_t</type>               <name>maxDescriptorSetInputAttachments</name></member>      <!-- max number of input attachments allowed in all stages in a descriptor set -->
-                <!-- vertex stage limits -->
-            <member><type>uint32_t</type>               <name>maxVertexInputAttributes</name></member>          <!-- max number of vertex input attribute slots -->
-            <member><type>uint32_t</type>               <name>maxVertexInputBindings</name></member>            <!-- max number of vertex input binding slots -->
-            <member><type>uint32_t</type>               <name>maxVertexInputAttributeOffset</name></member>     <!-- max vertex input attribute offset added to vertex buffer offset -->
-            <member><type>uint32_t</type>               <name>maxVertexInputBindingStride</name></member>       <!-- max vertex input binding stride -->
-            <member><type>uint32_t</type>               <name>maxVertexOutputComponents</name></member>         <!-- max number of output components written by vertex shader -->
-                <!-- tessellation control stage limits -->
-            <member><type>uint32_t</type>               <name>maxTessellationGenerationLevel</name></member>                   <!-- max level supported by tessellation primitive generator -->
-            <member><type>uint32_t</type>               <name>maxTessellationPatchSize</name></member>                  <!-- max patch size (vertices) -->
-            <member><type>uint32_t</type>               <name>maxTessellationControlPerVertexInputComponents</name></member>    <!-- max number of input components per-vertex in TCS -->
-            <member><type>uint32_t</type>               <name>maxTessellationControlPerVertexOutputComponents</name></member>   <!-- max number of output components per-vertex in TCS -->
-            <member><type>uint32_t</type>               <name>maxTessellationControlPerPatchOutputComponents</name></member>    <!-- max number of output components per-patch in TCS -->
-            <member><type>uint32_t</type>               <name>maxTessellationControlTotalOutputComponents</name></member>       <!-- max total number of per-vertex and per-patch output components in TCS -->
-                <!-- tessellation evaluation stage limits -->
-            <member><type>uint32_t</type>               <name>maxTessellationEvaluationInputComponents</name></member>  <!-- max number of input components per vertex in TES -->
-            <member><type>uint32_t</type>               <name>maxTessellationEvaluationOutputComponents</name></member> <!-- max number of output components per vertex in TES -->
-                <!-- geometry stage limits -->
-            <member><type>uint32_t</type>               <name>maxGeometryShaderInvocations</name></member>      <!-- max invocation count supported in geometry shader -->
-            <member><type>uint32_t</type>               <name>maxGeometryInputComponents</name></member>        <!-- max number of input components read in geometry stage -->
-            <member><type>uint32_t</type>               <name>maxGeometryOutputComponents</name></member>       <!-- max number of output components written in geometry stage -->
-            <member><type>uint32_t</type>               <name>maxGeometryOutputVertices</name></member>         <!-- max number of vertices that can be emitted in geometry stage -->
-            <member><type>uint32_t</type>               <name>maxGeometryTotalOutputComponents</name></member>  <!-- max total number of components (all vertices) written in geometry stage -->
-                <!-- fragment stage limits -->
-            <member><type>uint32_t</type>               <name>maxFragmentInputComponents</name></member>        <!-- max number of input compontents read in fragment stage -->
-            <member><type>uint32_t</type>               <name>maxFragmentOutputAttachments</name></member>      <!-- max number of output attachments written in fragment stage -->
-            <member><type>uint32_t</type>               <name>maxFragmentDualSrcAttachments</name></member>     <!-- max number of output attachments written when using dual source blending -->
-            <member><type>uint32_t</type>               <name>maxFragmentCombinedOutputResources</name></member><!-- max total number of storage buffers, storage images and output buffers -->
-                <!-- compute stage limits -->
-            <member><type>uint32_t</type>               <name>maxComputeSharedMemorySize</name></member>        <!-- max total storage size of work group local storage (bytes) -->
-            <member><type>uint32_t</type>               <name>maxComputeWorkGroupCount</name>[3]</member>       <!-- max num of compute work groups that may be dispatched by a single command (x,y,z) -->
-            <member><type>uint32_t</type>               <name>maxComputeWorkGroupInvocations</name></member>    <!-- max total compute invocations in a single local work group -->
-            <member><type>uint32_t</type>               <name>maxComputeWorkGroupSize</name>[3]</member>        <!-- max local size of a compute work group (x,y,z) -->
-            <member><type>uint32_t</type>               <name>subPixelPrecisionBits</name></member>             <!-- number bits of subpixel precision in screen x and y-->
-            <member><type>uint32_t</type>               <name>subTexelPrecisionBits</name></member>             <!-- number bits of precision for selecting texel weights-->
-            <member><type>uint32_t</type>               <name>mipmapPrecisionBits</name></member>               <!-- number bits of precision for selecting mipmap weights -->
-            <member><type>uint32_t</type>               <name>maxDrawIndexedIndexValue</name></member>          <!-- max index value for indexed draw calls (for 32-bit indices) -->
-            <member><type>uint32_t</type>               <name>maxDrawIndirectCount</name></member>              <!-- max draw count for indirect draw calls -->
-            <member><type>float</type>                  <name>maxSamplerLodBias</name></member>                 <!-- max absolute sampler level of detail bias -->
-            <member><type>float</type>                  <name>maxSamplerAnisotropy</name></member>              <!-- max degree of sampler anisotropy -->
-            <member><type>uint32_t</type>               <name>maxViewports</name></member>                      <!-- max number of active viewports -->
-            <member><type>uint32_t</type>               <name>maxViewportDimensions</name>[2]</member>          <!-- max viewport dimensions (x,y) -->
-            <member><type>float</type>                  <name>viewportBoundsRange</name>[2]</member>            <!-- viewport bounds range (min,max) -->
-            <member><type>uint32_t</type>               <name>viewportSubPixelBits</name></member>              <!-- number bits of subpixel precision for viewport -->
-            <member><type>size_t</type>                 <name>minMemoryMapAlignment</name></member>             <!-- min required alignment of pointers returned by MapMemory (bytes) -->
-            <member><type>VkDeviceSize</type>           <name>minTexelBufferOffsetAlignment</name></member>     <!-- min required alignment for texel buffer offsets (bytes)  -->
-            <member><type>VkDeviceSize</type>           <name>minUniformBufferOffsetAlignment</name></member>   <!-- min required alignment for uniform buffer sizes and offsets (bytes) -->
-            <member><type>VkDeviceSize</type>           <name>minStorageBufferOffsetAlignment</name></member>   <!-- min required alignment for storage buffer offsets (bytes) -->
-            <member><type>int32_t</type>                <name>minTexelOffset</name></member>                    <!-- min texel offset for OpTextureSampleOffset -->
-            <member><type>uint32_t</type>               <name>maxTexelOffset</name></member>                    <!-- max texel offset for OpTextureSampleOffset -->
-            <member><type>int32_t</type>                <name>minTexelGatherOffset</name></member>              <!-- min texel offset for OpTextureGatherOffset -->
-            <member><type>uint32_t</type>               <name>maxTexelGatherOffset</name></member>              <!-- max texel offset for OpTextureGatherOffset -->
-            <member><type>float</type>                  <name>minInterpolationOffset</name></member>            <!-- furthest negative offset for interpolateAtOffset -->
-            <member><type>float</type>                  <name>maxInterpolationOffset</name></member>            <!-- furthest positive offset for interpolateAtOffset -->
-            <member><type>uint32_t</type>               <name>subPixelInterpolationOffsetBits</name></member>   <!-- number of subpixel bits for interpolateAtOffset -->
-            <member><type>uint32_t</type>               <name>maxFramebufferWidth</name></member>               <!-- max width for a framebuffer -->
-            <member><type>uint32_t</type>               <name>maxFramebufferHeight</name></member>              <!-- max height for a framebuffer -->
-            <member><type>uint32_t</type>               <name>maxFramebufferLayers</name></member>              <!-- max layer count for a layered framebuffer -->
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>framebufferColorSampleCounts</name></member>      <!-- supported color sample counts for a framebuffer -->
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>framebufferDepthSampleCounts</name></member>      <!-- supported depth sample counts for a framebuffer -->
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>framebufferStencilSampleCounts</name></member>    <!-- supported stencil sample counts for a framebuffer -->
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>framebufferNoAttachmentsSampleCounts</name></member> <!-- supported sample counts for a framebuffer with no attachments -->
-            <member><type>uint32_t</type>               <name>maxColorAttachments</name></member>               <!-- max number of color attachments per subpass -->
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageColorSampleCounts</name></member>     <!-- supported color sample counts for a non-integer sampled image -->
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageIntegerSampleCounts</name></member>   <!-- supported sample counts for an integer image -->
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageDepthSampleCounts</name></member>     <!-- supported depth sample counts for a sampled image -->
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageStencilSampleCounts</name></member>   <!-- supported stencil sample counts for a sampled image -->
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>storageImageSampleCounts</name></member>          <!-- supported sample counts for a storage image -->
-            <member><type>uint32_t</type>               <name>maxSampleMaskWords</name></member>                <!-- max number of sample mask words -->
-            <member><type>VkBool32</type>               <name>timestampComputeAndGraphics</name></member>       <!-- timestamps on graphics and compute queues -->
-            <member><type>float</type>                  <name>timestampPeriod</name></member>                   <!-- number of nanoseconds it takes for timestamp query value to increment by 1 -->
-            <member><type>uint32_t</type>               <name>maxClipDistances</name></member>                  <!-- max number of clip distances -->
-            <member><type>uint32_t</type>               <name>maxCullDistances</name></member>                  <!-- max number of cull distances -->
-            <member><type>uint32_t</type>               <name>maxCombinedClipAndCullDistances</name></member>   <!-- max combined number of user clipping -->
-            <member><type>uint32_t</type>               <name>discreteQueuePriorities</name></member>           <!-- distinct queue priorities available  -->
-            <member><type>float</type>                  <name>pointSizeRange</name>[2]</member>                 <!-- range (min,max) of supported point sizes -->
-            <member><type>float</type>                  <name>lineWidthRange</name>[2]</member>                 <!-- range (min,max) of supported line widths -->
-            <member><type>float</type>                  <name>pointSizeGranularity</name></member>              <!-- granularity of supported point sizes -->
-            <member><type>float</type>                  <name>lineWidthGranularity</name></member>              <!-- granularity of supported line widths -->
-            <member><type>VkBool32</type>               <name>strictLines</name></member>                       <!-- line rasterization follows preferred rules -->
-            <member><type>VkBool32</type>               <name>standardSampleLocations</name></member>           <!-- supports standard sample locations for all supported sample counts -->
-            <member><type>VkDeviceSize</type>           <name>optimalBufferCopyOffsetAlignment</name></member>  <!-- optimal offset of buffer copies -->
-            <member><type>VkDeviceSize</type>           <name>optimalBufferCopyRowPitchAlignment</name></member><!-- optimal pitch of buffer copies -->
-            <member><type>VkDeviceSize</type>           <name>nonCoherentAtomSize</name></member>               <!-- minimum size and alignment for non-coherent host-mapped device memory access -->
+                <comment>resource maximum sizes</comment>
+            <member><type>uint32_t</type>               <name>maxImageDimension1D</name><comment>max 1D image dimension</comment></member>
+            <member><type>uint32_t</type>               <name>maxImageDimension2D</name><comment>max 2D image dimension</comment></member>
+            <member><type>uint32_t</type>               <name>maxImageDimension3D</name><comment>max 3D image dimension</comment></member>
+            <member><type>uint32_t</type>               <name>maxImageDimensionCube</name><comment>max cubemap image dimension</comment></member>
+            <member><type>uint32_t</type>               <name>maxImageArrayLayers</name><comment>max layers for image arrays</comment></member>
+            <member><type>uint32_t</type>               <name>maxTexelBufferElements</name><comment>max texel buffer size (fstexels)</comment></member>
+            <member><type>uint32_t</type>               <name>maxUniformBufferRange</name><comment>max uniform buffer range (bytes)</comment></member>
+            <member><type>uint32_t</type>               <name>maxStorageBufferRange</name><comment>max storage buffer range (bytes)</comment></member>
+            <member><type>uint32_t</type>               <name>maxPushConstantsSize</name><comment>max size of the push constants pool (bytes)</comment></member>
+                <comment>memory limits</comment>
+            <member><type>uint32_t</type>               <name>maxMemoryAllocationCount</name><comment>max number of device memory allocations supported</comment></member>
+            <member><type>uint32_t</type>               <name>maxSamplerAllocationCount</name><comment>max number of samplers that can be allocated on a device</comment></member>
+            <member><type>VkDeviceSize</type>           <name>bufferImageGranularity</name><comment>Granularity (in bytes) at which buffers and images can be bound to adjacent memory for simultaneous usage</comment></member>
+            <member><type>VkDeviceSize</type>           <name>sparseAddressSpaceSize</name><comment>Total address space available for sparse allocations (bytes)</comment></member>
+                <comment>descriptor set limits</comment>
+            <member><type>uint32_t</type>               <name>maxBoundDescriptorSets</name><comment>max number of descriptors sets that can be bound to a pipeline</comment></member>
+            <member><type>uint32_t</type>               <name>maxPerStageDescriptorSamplers</name><comment>max number of samplers allowed per-stage in a descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>maxPerStageDescriptorUniformBuffers</name><comment>max number of uniform buffers allowed per-stage in a descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>maxPerStageDescriptorStorageBuffers</name><comment>max number of storage buffers allowed per-stage in a descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>maxPerStageDescriptorSampledImages</name><comment>max number of sampled images allowed per-stage in a descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>maxPerStageDescriptorStorageImages</name><comment>max number of storage images allowed per-stage in a descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>maxPerStageDescriptorInputAttachments</name><comment>max number of input attachments allowed per-stage in a descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>maxPerStageResources</name><comment>max number of resources allowed by a single stage</comment></member>
+            <member><type>uint32_t</type>               <name>maxDescriptorSetSamplers</name><comment>max number of samplers allowed in all stages in a descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>maxDescriptorSetUniformBuffers</name><comment>max number of uniform buffers allowed in all stages in a descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>maxDescriptorSetUniformBuffersDynamic</name><comment>max number of dynamic uniform buffers allowed in all stages in a descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>maxDescriptorSetStorageBuffers</name><comment>max number of storage buffers allowed in all stages in a descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>maxDescriptorSetStorageBuffersDynamic</name><comment>max number of dynamic storage buffers allowed in all stages in a descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>maxDescriptorSetSampledImages</name><comment>max number of sampled images allowed in all stages in a descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>maxDescriptorSetStorageImages</name><comment>max number of storage images allowed in all stages in a descriptor set</comment></member>
+            <member><type>uint32_t</type>               <name>maxDescriptorSetInputAttachments</name><comment>max number of input attachments allowed in all stages in a descriptor set</comment></member>
+                <comment>vertex stage limits</comment>
+            <member><type>uint32_t</type>               <name>maxVertexInputAttributes</name><comment>max number of vertex input attribute slots</comment></member>
+            <member><type>uint32_t</type>               <name>maxVertexInputBindings</name><comment>max number of vertex input binding slots</comment></member>
+            <member><type>uint32_t</type>               <name>maxVertexInputAttributeOffset</name><comment>max vertex input attribute offset added to vertex buffer offset</comment></member>
+            <member><type>uint32_t</type>               <name>maxVertexInputBindingStride</name><comment>max vertex input binding stride</comment></member>
+            <member><type>uint32_t</type>               <name>maxVertexOutputComponents</name><comment>max number of output components written by vertex shader</comment></member>
+                <comment>tessellation control stage limits</comment>
+            <member><type>uint32_t</type>               <name>maxTessellationGenerationLevel</name><comment>max level supported by tessellation primitive generator</comment></member>
+            <member><type>uint32_t</type>               <name>maxTessellationPatchSize</name><comment>max patch size (vertices)</comment></member>
+            <member><type>uint32_t</type>               <name>maxTessellationControlPerVertexInputComponents</name><comment>max number of input components per-vertex in TCS</comment></member>
+            <member><type>uint32_t</type>               <name>maxTessellationControlPerVertexOutputComponents</name><comment>max number of output components per-vertex in TCS</comment></member>
+            <member><type>uint32_t</type>               <name>maxTessellationControlPerPatchOutputComponents</name><comment>max number of output components per-patch in TCS</comment></member>
+            <member><type>uint32_t</type>               <name>maxTessellationControlTotalOutputComponents</name><comment>max total number of per-vertex and per-patch output components in TCS</comment></member>
+                <comment>tessellation evaluation stage limits</comment>
+            <member><type>uint32_t</type>               <name>maxTessellationEvaluationInputComponents</name><comment>max number of input components per vertex in TES</comment></member>
+            <member><type>uint32_t</type>               <name>maxTessellationEvaluationOutputComponents</name><comment>max number of output components per vertex in TES</comment></member>
+                <comment>geometry stage limits</comment>
+            <member><type>uint32_t</type>               <name>maxGeometryShaderInvocations</name><comment>max invocation count supported in geometry shader</comment></member>
+            <member><type>uint32_t</type>               <name>maxGeometryInputComponents</name><comment>max number of input components read in geometry stage</comment></member>
+            <member><type>uint32_t</type>               <name>maxGeometryOutputComponents</name><comment>max number of output components written in geometry stage</comment></member>
+            <member><type>uint32_t</type>               <name>maxGeometryOutputVertices</name><comment>max number of vertices that can be emitted in geometry stage</comment></member>
+            <member><type>uint32_t</type>               <name>maxGeometryTotalOutputComponents</name><comment>max total number of components (all vertices) written in geometry stage</comment></member>
+                <comment>fragment stage limits</comment>
+            <member><type>uint32_t</type>               <name>maxFragmentInputComponents</name><comment>max number of input compontents read in fragment stage</comment></member>
+            <member><type>uint32_t</type>               <name>maxFragmentOutputAttachments</name><comment>max number of output attachments written in fragment stage</comment></member>
+            <member><type>uint32_t</type>               <name>maxFragmentDualSrcAttachments</name><comment>max number of output attachments written when using dual source blending</comment></member>
+            <member><type>uint32_t</type>               <name>maxFragmentCombinedOutputResources</name><comment>max total number of storage buffers, storage images and output buffers</comment></member>
+                <comment>compute stage limits</comment>
+            <member><type>uint32_t</type>               <name>maxComputeSharedMemorySize</name><comment>max total storage size of work group local storage (bytes)</comment></member>
+            <member><type>uint32_t</type>               <name>maxComputeWorkGroupCount</name>[3]<comment>max num of compute work groups that may be dispatched by a single command (x,y,z)</comment></member>
+            <member><type>uint32_t</type>               <name>maxComputeWorkGroupInvocations</name><comment>max total compute invocations in a single local work group</comment></member>
+            <member><type>uint32_t</type>               <name>maxComputeWorkGroupSize</name>[3]<comment>max local size of a compute work group (x,y,z)</comment></member>
+            <member><type>uint32_t</type>               <name>subPixelPrecisionBits</name><comment>number bits of subpixel precision in screen x and y</comment></member>
+            <member><type>uint32_t</type>               <name>subTexelPrecisionBits</name><comment>number bits of precision for selecting texel weights</comment></member>
+            <member><type>uint32_t</type>               <name>mipmapPrecisionBits</name><comment>number bits of precision for selecting mipmap weights</comment></member>
+            <member><type>uint32_t</type>               <name>maxDrawIndexedIndexValue</name><comment>max index value for indexed draw calls (for 32-bit indices)</comment></member>
+            <member><type>uint32_t</type>               <name>maxDrawIndirectCount</name><comment>max draw count for indirect draw calls</comment></member>
+            <member><type>float</type>                  <name>maxSamplerLodBias</name><comment>max absolute sampler level of detail bias</comment></member>
+            <member><type>float</type>                  <name>maxSamplerAnisotropy</name><comment>max degree of sampler anisotropy</comment></member>
+            <member><type>uint32_t</type>               <name>maxViewports</name><comment>max number of active viewports</comment></member>
+            <member><type>uint32_t</type>               <name>maxViewportDimensions</name>[2]<comment>max viewport dimensions (x,y)</comment></member>
+            <member><type>float</type>                  <name>viewportBoundsRange</name>[2]<comment>viewport bounds range (min,max)</comment></member>
+            <member><type>uint32_t</type>               <name>viewportSubPixelBits</name><comment>number bits of subpixel precision for viewport</comment></member>
+            <member><type>size_t</type>                 <name>minMemoryMapAlignment</name><comment>min required alignment of pointers returned by MapMemory (bytes)</comment></member>
+            <member><type>VkDeviceSize</type>           <name>minTexelBufferOffsetAlignment</name><comment>min required alignment for texel buffer offsets (bytes) </comment></member>
+            <member><type>VkDeviceSize</type>           <name>minUniformBufferOffsetAlignment</name><comment>min required alignment for uniform buffer sizes and offsets (bytes)</comment></member>
+            <member><type>VkDeviceSize</type>           <name>minStorageBufferOffsetAlignment</name><comment>min required alignment for storage buffer offsets (bytes)</comment></member>
+            <member><type>int32_t</type>                <name>minTexelOffset</name><comment>min texel offset for OpTextureSampleOffset</comment></member>
+            <member><type>uint32_t</type>               <name>maxTexelOffset</name><comment>max texel offset for OpTextureSampleOffset</comment></member>
+            <member><type>int32_t</type>                <name>minTexelGatherOffset</name><comment>min texel offset for OpTextureGatherOffset</comment></member>
+            <member><type>uint32_t</type>               <name>maxTexelGatherOffset</name><comment>max texel offset for OpTextureGatherOffset</comment></member>
+            <member><type>float</type>                  <name>minInterpolationOffset</name><comment>furthest negative offset for interpolateAtOffset</comment></member>
+            <member><type>float</type>                  <name>maxInterpolationOffset</name><comment>furthest positive offset for interpolateAtOffset</comment></member>
+            <member><type>uint32_t</type>               <name>subPixelInterpolationOffsetBits</name><comment>number of subpixel bits for interpolateAtOffset</comment></member>
+            <member><type>uint32_t</type>               <name>maxFramebufferWidth</name><comment>max width for a framebuffer</comment></member>
+            <member><type>uint32_t</type>               <name>maxFramebufferHeight</name><comment>max height for a framebuffer</comment></member>
+            <member><type>uint32_t</type>               <name>maxFramebufferLayers</name><comment>max layer count for a layered framebuffer</comment></member>
+            <member optional="true"><type>VkSampleCountFlags</type>     <name>framebufferColorSampleCounts</name><comment>supported color sample counts for a framebuffer</comment></member>
+            <member optional="true"><type>VkSampleCountFlags</type>     <name>framebufferDepthSampleCounts</name><comment>supported depth sample counts for a framebuffer</comment></member>
+            <member optional="true"><type>VkSampleCountFlags</type>     <name>framebufferStencilSampleCounts</name><comment>supported stencil sample counts for a framebuffer</comment></member>
+            <member optional="true"><type>VkSampleCountFlags</type>     <name>framebufferNoAttachmentsSampleCounts</name><comment>supported sample counts for a framebuffer with no attachments</comment></member>
+            <member><type>uint32_t</type>               <name>maxColorAttachments</name><comment>max number of color attachments per subpass</comment></member>
+            <member optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageColorSampleCounts</name><comment>supported color sample counts for a non-integer sampled image</comment></member>
+            <member optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageIntegerSampleCounts</name><comment>supported sample counts for an integer image</comment></member>
+            <member optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageDepthSampleCounts</name><comment>supported depth sample counts for a sampled image</comment></member>
+            <member optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageStencilSampleCounts</name><comment>supported stencil sample counts for a sampled image</comment></member>
+            <member optional="true"><type>VkSampleCountFlags</type>     <name>storageImageSampleCounts</name><comment>supported sample counts for a storage image</comment></member>
+            <member><type>uint32_t</type>               <name>maxSampleMaskWords</name><comment>max number of sample mask words</comment></member>
+            <member><type>VkBool32</type>               <name>timestampComputeAndGraphics</name><comment>timestamps on graphics and compute queues</comment></member>
+            <member><type>float</type>                  <name>timestampPeriod</name><comment>number of nanoseconds it takes for timestamp query value to increment by 1</comment></member>
+            <member><type>uint32_t</type>               <name>maxClipDistances</name><comment>max number of clip distances</comment></member>
+            <member><type>uint32_t</type>               <name>maxCullDistances</name><comment>max number of cull distances</comment></member>
+            <member><type>uint32_t</type>               <name>maxCombinedClipAndCullDistances</name><comment>max combined number of user clipping</comment></member>
+            <member><type>uint32_t</type>               <name>discreteQueuePriorities</name><comment>distinct queue priorities available </comment></member>
+            <member><type>float</type>                  <name>pointSizeRange</name>[2]<comment>range (min,max) of supported point sizes</comment></member>
+            <member><type>float</type>                  <name>lineWidthRange</name>[2]<comment>range (min,max) of supported line widths</comment></member>
+            <member><type>float</type>                  <name>pointSizeGranularity</name><comment>granularity of supported point sizes</comment></member>
+            <member><type>float</type>                  <name>lineWidthGranularity</name><comment>granularity of supported line widths</comment></member>
+            <member><type>VkBool32</type>               <name>strictLines</name><comment>line rasterization follows preferred rules</comment></member>
+            <member><type>VkBool32</type>               <name>standardSampleLocations</name><comment>supports standard sample locations for all supported sample counts</comment></member>
+            <member><type>VkDeviceSize</type>           <name>optimalBufferCopyOffsetAlignment</name><comment>optimal offset of buffer copies</comment></member>
+            <member><type>VkDeviceSize</type>           <name>optimalBufferCopyRowPitchAlignment</name><comment>optimal pitch of buffer copies</comment></member>
+            <member><type>VkDeviceSize</type>           <name>nonCoherentAtomSize</name><comment>minimum size and alignment for non-coherent host-mapped device memory access</comment></member>
         </type>
         <type category="struct" name="VkSemaphoreCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkSemaphoreCreateFlags</type> <name>flags</name></member>                          <!-- Semaphore creation flags -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkSemaphoreCreateFlags</type> <name>flags</name><comment>Semaphore creation flags</comment></member>
         </type>
         <type category="struct" name="VkQueryPoolCreateInfo">
             <member values="VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkQueryPoolCreateFlags</type> <name>flags</name></member>                          <!-- Reserved -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkQueryPoolCreateFlags</type> <name>flags</name></member>
             <member><type>VkQueryType</type>            <name>queryType</name></member>
             <member><type>uint32_t</type>               <name>queryCount</name></member>
-            <member optional="true" noautovalidity="true"><type>VkQueryPipelineStatisticFlags</type> <name>pipelineStatistics</name></member>      <!-- Optional -->
+            <member optional="true" noautovalidity="true"><type>VkQueryPipelineStatisticFlags</type> <name>pipelineStatistics</name><comment>Optional</comment></member>
         </type>
         <type category="struct" name="VkFramebufferCreateInfo">
             <member values="VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
-            <member optional="true"><type>VkFramebufferCreateFlags</type>    <name>flags</name></member>                     <!-- Reserved -->
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkFramebufferCreateFlags</type>    <name>flags</name></member>
             <member><type>VkRenderPass</type>           <name>renderPass</name></member>
             <member optional="true"><type>uint32_t</type>               <name>attachmentCount</name></member>
             <member len="attachmentCount">const <type>VkImageView</type>*     <name>pAttachments</name></member>
@@ -1371,7 +1425,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkSubmitInfo">
             <member values="VK_STRUCTURE_TYPE_SUBMIT_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
+            <member>const <type>void</type>* <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>       <name>waitSemaphoreCount</name></member>
             <member len="waitSemaphoreCount">const <type>VkSemaphore</type>*     <name>pWaitSemaphores</name></member>
             <member len="waitSemaphoreCount">const <type>VkPipelineStageFlags</type>*           <name>pWaitDstStageMask</name></member>
@@ -1380,37 +1434,37 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member optional="true"><type>uint32_t</type>       <name>signalSemaphoreCount</name></member>
             <member len="signalSemaphoreCount">const <type>VkSemaphore</type>*     <name>pSignalSemaphores</name></member>
         </type>
-        <!-- WSI extensions -->
+            <comment>WSI extensions</comment>
         <type category="struct" name="VkDisplayPropertiesKHR" returnedonly="true">
-            <member><type>VkDisplayKHR</type>                     <name>display</name></member>                  <!-- Handle of the display object -->
-            <member len="null-terminated">const <type>char</type>*                      <name>displayName</name></member>              <!-- Name of the display -->
-            <member><type>VkExtent2D</type>                       <name>physicalDimensions</name></member>       <!-- In millimeters? -->
-            <member><type>VkExtent2D</type>                       <name>physicalResolution</name></member>       <!-- Max resolution for CRT? -->
-            <member optional="true"><type>VkSurfaceTransformFlagsKHR</type>       <name>supportedTransforms</name></member>      <!-- one or more bits from VkSurfaceTransformFlagsKHR -->
-            <member><type>VkBool32</type>                         <name>planeReorderPossible</name></member>     <!-- VK_TRUE if the overlay plane's z-order can be changed on this display. -->
-            <member><type>VkBool32</type>                         <name>persistentContent</name></member>        <!-- VK_TRUE if this is a "smart" display that supports self-refresh/internal buffering. -->
+            <member><type>VkDisplayKHR</type>                     <name>display</name><comment>Handle of the display object</comment></member>
+            <member len="null-terminated">const <type>char</type>*                      <name>displayName</name><comment>Name of the display</comment></member>
+            <member><type>VkExtent2D</type>                       <name>physicalDimensions</name><comment>In millimeters?</comment></member>
+            <member><type>VkExtent2D</type>                       <name>physicalResolution</name><comment>Max resolution for CRT?</comment></member>
+            <member optional="true"><type>VkSurfaceTransformFlagsKHR</type>       <name>supportedTransforms</name><comment>one or more bits from VkSurfaceTransformFlagsKHR</comment></member>
+            <member><type>VkBool32</type>                         <name>planeReorderPossible</name><comment>VK_TRUE if the overlay plane's z-order can be changed on this display.</comment></member>
+            <member><type>VkBool32</type>                         <name>persistentContent</name><comment>VK_TRUE if this is a "smart" display that supports self-refresh/internal buffering.</comment></member>
         </type>
         <type category="struct" name="VkDisplayPlanePropertiesKHR" returnedonly="true">
-            <member><type>VkDisplayKHR</type>                     <name>currentDisplay</name></member>           <!-- Display the plane is currently associated with.  Will be VK_NULL_HANDLE if the plane is not in use. -->
-            <member><type>uint32_t</type>                         <name>currentStackIndex</name></member>        <!-- Current z-order of the plane. -->
+            <member><type>VkDisplayKHR</type>                     <name>currentDisplay</name><comment>Display the plane is currently associated with.  Will be VK_NULL_HANDLE if the plane is not in use.</comment></member>
+            <member><type>uint32_t</type>                         <name>currentStackIndex</name><comment>Current z-order of the plane.</comment></member>
         </type>
         <type category="struct" name="VkDisplayModeParametersKHR">
-            <member><type>VkExtent2D</type>                       <name>visibleRegion</name></member>            <!-- Visible scanout region. -->
-            <member><type>uint32_t</type>                         <name>refreshRate</name></member>              <!-- Number of times per second the display is updated. -->
+            <member><type>VkExtent2D</type>                       <name>visibleRegion</name><comment>Visible scanout region.</comment></member>
+            <member><type>uint32_t</type>                         <name>refreshRate</name><comment>Number of times per second the display is updated.</comment></member>
         </type>
         <type category="struct" name="VkDisplayModePropertiesKHR" returnedonly="true">
-            <member><type>VkDisplayModeKHR</type>                 <name>displayMode</name></member>              <!-- Handle of this display mode. -->
-            <member><type>VkDisplayModeParametersKHR</type>       <name>parameters</name></member>               <!-- The parameters this mode uses. -->
+            <member><type>VkDisplayModeKHR</type>                 <name>displayMode</name><comment>Handle of this display mode.</comment></member>
+            <member><type>VkDisplayModeParametersKHR</type>       <name>parameters</name><comment>The parameters this mode uses.</comment></member>
         </type>
         <type category="struct" name="VkDisplayModeCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_MODE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member optional="true"><type>VkDisplayModeCreateFlagsKHR</type>      <name>flags</name></member>                    <!-- Reserved -->
-            <member><type>VkDisplayModeParametersKHR</type>       <name>parameters</name></member>               <!-- The parameters this mode uses. -->
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkDisplayModeCreateFlagsKHR</type>      <name>flags</name></member>
+            <member><type>VkDisplayModeParametersKHR</type>       <name>parameters</name><comment>The parameters this mode uses.</comment></member>
         </type>
         <type category="struct" name="VkDisplayPlaneCapabilitiesKHR" returnedonly="true">
-            <member optional="true"><type>VkDisplayPlaneAlphaFlagsKHR</type>      <name>supportedAlpha</name></member>           <!-- Types of alpha blending supported, if any. -->
-            <member><type>VkOffset2D</type>                       <name>minSrcPosition</name></member>           <!-- Does the plane have any position and extent restrictions? -->
+            <member optional="true"><type>VkDisplayPlaneAlphaFlagsKHR</type>      <name>supportedAlpha</name><comment>Types of alpha blending supported, if any.</comment></member>
+            <member><type>VkOffset2D</type>                       <name>minSrcPosition</name><comment>Does the plane have any position and extent restrictions?</comment></member>
             <member><type>VkOffset2D</type>                       <name>maxSrcPosition</name></member>
             <member><type>VkExtent2D</type>                       <name>minSrcExtent</name></member>
             <member><type>VkExtent2D</type>                       <name>maxSrcExtent</name></member>
@@ -1421,165 +1475,171 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkDisplaySurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member optional="true"><type>VkDisplaySurfaceCreateFlagsKHR</type>   <name>flags</name></member>                    <!-- Reserved -->
-            <member><type>VkDisplayModeKHR</type>                 <name>displayMode</name></member>              <!-- The mode to use when displaying this surface -->
-            <member><type>uint32_t</type>                         <name>planeIndex</name></member>               <!-- The plane on which this surface appears.  Must be between 0 and the value returned by vkGetPhysicalDeviceDisplayPlanePropertiesKHR() in pPropertyCount. -->
-            <member><type>uint32_t</type>                         <name>planeStackIndex</name></member>          <!-- The z-order of the plane. -->
-            <member><type>VkSurfaceTransformFlagBitsKHR</type>    <name>transform</name></member>                <!-- Transform to apply to the images as part of the scanout operation -->
-            <member><type>float</type>                            <name>globalAlpha</name></member>              <!-- Global alpha value.  Must be between 0 and 1, inclusive.  Ignored if alphaMode is not VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR -->
-            <member><type>VkDisplayPlaneAlphaFlagBitsKHR</type>   <name>alphaMode</name></member>                <!-- What type of alpha blending to use.  Must be a bit from vkGetDisplayPlanePropertiesKHR::supportedAlpha. -->
-            <member><type>VkExtent2D</type>                       <name>imageExtent</name></member>              <!-- size of the images to use with this surface -->
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkDisplaySurfaceCreateFlagsKHR</type>   <name>flags</name></member>
+            <member><type>VkDisplayModeKHR</type>                 <name>displayMode</name><comment>The mode to use when displaying this surface</comment></member>
+            <member><type>uint32_t</type>                         <name>planeIndex</name><comment>The plane on which this surface appears.  Must be between 0 and the value returned by vkGetPhysicalDeviceDisplayPlanePropertiesKHR() in pPropertyCount.</comment></member>
+            <member><type>uint32_t</type>                         <name>planeStackIndex</name><comment>The z-order of the plane.</comment></member>
+            <member><type>VkSurfaceTransformFlagBitsKHR</type>    <name>transform</name><comment>Transform to apply to the images as part of the scanout operation</comment></member>
+            <member><type>float</type>                            <name>globalAlpha</name><comment>Global alpha value.  Must be between 0 and 1, inclusive.  Ignored if alphaMode is not VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR</comment></member>
+            <member><type>VkDisplayPlaneAlphaFlagBitsKHR</type>   <name>alphaMode</name><comment>What type of alpha blending to use.  Must be a bit from vkGetDisplayPlanePropertiesKHR::supportedAlpha.</comment></member>
+            <member><type>VkExtent2D</type>                       <name>imageExtent</name><comment>size of the images to use with this surface</comment></member>
         </type>
-        <type category="struct" name="VkDisplayPresentInfoKHR">
+        <type category="struct" name="VkDisplayPresentInfoKHR" structextends="VkPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_PRESENT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member><type>VkRect2D</type>                         <name>srcRect</name></member>                  <!-- Rectangle within the presentable image to read pixel data from when presenting to the display. -->
-            <member><type>VkRect2D</type>                         <name>dstRect</name></member>                  <!-- Rectangle within the current display mode's visible region to display srcRectangle in. -->
-            <member><type>VkBool32</type>                         <name>persistent</name></member>               <!-- For smart displays, use buffered mode.  If the display properties member "persistentMode" is VK_FALSE, this member must always be VK_FALSE. -->
+            <member noautovalidity="true">const <type>void</type>*  <name>pNext</name></member>
+            <member><type>VkRect2D</type>                         <name>srcRect</name><comment>Rectangle within the presentable image to read pixel data from when presenting to the display.</comment></member>
+            <member><type>VkRect2D</type>                         <name>dstRect</name><comment>Rectangle within the current display mode's visible region to display srcRectangle in.</comment></member>
+            <member><type>VkBool32</type>                         <name>persistent</name><comment>For smart displays, use buffered mode.  If the display properties member "persistentMode" is VK_FALSE, this member must always be VK_FALSE.</comment></member>
         </type>
         <type category="struct" name="VkSurfaceCapabilitiesKHR" returnedonly="true">
-            <member><type>uint32_t</type>                         <name>minImageCount</name></member>            <!-- Supported minimum number of images for the surface -->
-            <member><type>uint32_t</type>                         <name>maxImageCount</name></member>            <!-- Supported maximum number of images for the surface, 0 for unlimited -->
-            <member><type>VkExtent2D</type>                       <name>currentExtent</name></member>            <!-- Current image width and height for the surface, (0, 0) if undefined -->
-            <member><type>VkExtent2D</type>                       <name>minImageExtent</name></member>           <!-- Supported minimum image width and height for the surface -->
-            <member><type>VkExtent2D</type>                       <name>maxImageExtent</name></member>           <!-- Supported maximum image width and height for the surface -->
-            <member><type>uint32_t</type>                         <name>maxImageArrayLayers</name></member>      <!-- Supported maximum number of image layers for the surface -->
-            <member optional="true"><type>VkSurfaceTransformFlagsKHR</type>       <name>supportedTransforms</name></member>      <!-- 1 or more bits representing the transforms supported -->
-            <member><type>VkSurfaceTransformFlagBitsKHR</type>    <name>currentTransform</name></member>         <!-- The surface's current transform relative to the device's natural orientation -->
-            <member optional="true"><type>VkCompositeAlphaFlagsKHR</type>         <name>supportedCompositeAlpha</name></member>  <!-- 1 or more bits representing the alpha compositing modes supported -->
-            <member optional="true"><type>VkImageUsageFlags</type>                <name>supportedUsageFlags</name></member>      <!-- Supported image usage flags for the surface -->
+            <member><type>uint32_t</type>                         <name>minImageCount</name><comment>Supported minimum number of images for the surface</comment></member>
+            <member><type>uint32_t</type>                         <name>maxImageCount</name><comment>Supported maximum number of images for the surface, 0 for unlimited</comment></member>
+            <member><type>VkExtent2D</type>                       <name>currentExtent</name><comment>Current image width and height for the surface, (0, 0) if undefined</comment></member>
+            <member><type>VkExtent2D</type>                       <name>minImageExtent</name><comment>Supported minimum image width and height for the surface</comment></member>
+            <member><type>VkExtent2D</type>                       <name>maxImageExtent</name><comment>Supported maximum image width and height for the surface</comment></member>
+            <member><type>uint32_t</type>                         <name>maxImageArrayLayers</name><comment>Supported maximum number of image layers for the surface</comment></member>
+            <member optional="true"><type>VkSurfaceTransformFlagsKHR</type>       <name>supportedTransforms</name><comment>1 or more bits representing the transforms supported</comment></member>
+            <member><type>VkSurfaceTransformFlagBitsKHR</type>    <name>currentTransform</name><comment>The surface's current transform relative to the device's natural orientation</comment></member>
+            <member optional="true"><type>VkCompositeAlphaFlagsKHR</type>         <name>supportedCompositeAlpha</name><comment>1 or more bits representing the alpha compositing modes supported</comment></member>
+            <member optional="true"><type>VkImageUsageFlags</type>                <name>supportedUsageFlags</name><comment>Supported image usage flags for the surface</comment></member>
         </type>
         <type category="struct" name="VkAndroidSurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member optional="true"><type>VkAndroidSurfaceCreateFlagsKHR</type>   <name>flags</name></member>    <!-- Reserved -->
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkAndroidSurfaceCreateFlagsKHR</type>   <name>flags</name></member>
             <member noautovalidity="true"><type>ANativeWindow</type>*                   <name>window</name></member>
         </type>
         <type category="struct" name="VkMirSurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_MIR_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member optional="true"><type>VkMirSurfaceCreateFlagsKHR</type>   <name>flags</name></member>        <!-- Reserved -->
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkMirSurfaceCreateFlagsKHR</type>   <name>flags</name></member>
             <member noautovalidity="true"><type>MirConnection</type>*                   <name>connection</name></member>
             <member noautovalidity="true"><type>MirSurface</type>*                      <name>mirSurface</name></member>
         </type>
+        <type category="struct" name="VkViSurfaceCreateInfoNN">
+            <member values="VK_STRUCTURE_TYPE_VI_SURFACE_CREATE_INFO_NN"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkViSurfaceCreateFlagsNN</type>   <name>flags</name></member>
+            <member><type>void</type>*                            <name>window</name></member>
+        </type>
         <type category="struct" name="VkWaylandSurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member optional="true"><type>VkWaylandSurfaceCreateFlagsKHR</type>   <name>flags</name></member>    <!-- Reserved -->
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkWaylandSurfaceCreateFlagsKHR</type>   <name>flags</name></member>
             <member noautovalidity="true">struct <type>wl_display</type>*               <name>display</name></member>
             <member noautovalidity="true">struct <type>wl_surface</type>*               <name>surface</name></member>
         </type>
         <type category="struct" name="VkWin32SurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member optional="true"><type>VkWin32SurfaceCreateFlagsKHR</type>   <name>flags</name></member>      <!-- Reserved -->
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkWin32SurfaceCreateFlagsKHR</type>   <name>flags</name></member>
             <member><type>HINSTANCE</type>                        <name>hinstance</name></member>
             <member><type>HWND</type>                             <name>hwnd</name></member>
         </type>
         <type category="struct" name="VkXlibSurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member optional="true"><type>VkXlibSurfaceCreateFlagsKHR</type>   <name>flags</name></member>       <!-- Reserved -->
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkXlibSurfaceCreateFlagsKHR</type>   <name>flags</name></member>
             <member noautovalidity="true"><type>Display</type>*                         <name>dpy</name></member>
             <member><type>Window</type>                           <name>window</name></member>
         </type>
         <type category="struct" name="VkXcbSurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member optional="true"><type>VkXcbSurfaceCreateFlagsKHR</type>   <name>flags</name></member>        <!-- Reserved -->
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkXcbSurfaceCreateFlagsKHR</type>   <name>flags</name></member>
             <member noautovalidity="true"><type>xcb_connection_t</type>*                <name>connection</name></member>
             <member><type>xcb_window_t</type>                     <name>window</name></member>
         </type>
         <type category="struct" name="VkSurfaceFormatKHR" returnedonly="true">
-            <member><type>VkFormat</type>                         <name>format</name></member>                   <!-- Supported pair of rendering format -->
-            <member><type>VkColorSpaceKHR</type>                  <name>colorSpace</name></member>               <!-- and color space for the surface -->
+            <member><type>VkFormat</type>                         <name>format</name><comment>Supported pair of rendering format</comment></member>
+            <member><type>VkColorSpaceKHR</type>                  <name>colorSpace</name><comment>and color space for the surface</comment></member>
         </type>
         <type category="struct" name="VkSwapchainCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member optional="true"><type>VkSwapchainCreateFlagsKHR</type>        <name>flags</name></member>                    <!-- Reserved -->
-            <member><type>VkSurfaceKHR</type>                     <name>surface</name></member>                  <!-- The swapchain's target surface -->
-            <member><type>uint32_t</type>                         <name>minImageCount</name></member>            <!-- Minimum number of presentation images the application needs -->
-            <member><type>VkFormat</type>                         <name>imageFormat</name></member>              <!-- Format of the presentation images -->
-            <member><type>VkColorSpaceKHR</type>                  <name>imageColorSpace</name></member>          <!-- Colorspace of the presentation images -->
-            <member><type>VkExtent2D</type>                       <name>imageExtent</name></member>              <!-- Dimensions of the presentation images -->
-            <member><type>uint32_t</type>                         <name>imageArrayLayers</name></member>         <!-- Determines the number of views for multiview/stereo presentation -->
-            <member><type>VkImageUsageFlags</type>                <name>imageUsage</name></member>               <!-- Bits indicating how the presentation images will be used -->
-            <member><type>VkSharingMode</type>                    <name>imageSharingMode</name></member>         <!-- Sharing mode used for the presentation images -->
-            <member optional="true"><type>uint32_t</type>         <name>queueFamilyIndexCount</name></member>    <!-- Number of queue families having access to the images in case of concurrent sharing mode -->
-            <member noautovalidity="true" len="queueFamilyIndexCount">const <type>uint32_t</type>*                  <name>pQueueFamilyIndices</name></member>      <!-- Array of queue family indices having access to the images in case of concurrent sharing mode -->
-            <member><type>VkSurfaceTransformFlagBitsKHR</type>    <name>preTransform</name></member>             <!-- The transform, relative to the device's natural orientation, applied to the image content prior to presentation -->
-            <member><type>VkCompositeAlphaFlagBitsKHR</type>      <name>compositeAlpha</name></member>           <!-- The alpha blending mode used when compositing this surface with other surfaces in the window system -->
-            <member><type>VkPresentModeKHR</type>                 <name>presentMode</name></member>              <!-- Which presentation mode to use for presents on this swap chain -->
-            <member><type>VkBool32</type>                         <name>clipped</name></member>                  <!-- Specifies whether presentable images may be affected by window clip regions -->
-            <member optional="true"><type>VkSwapchainKHR</type>   <name>oldSwapchain</name></member>             <!-- Existing swap chain to replace, if any -->
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkSwapchainCreateFlagsKHR</type>        <name>flags</name></member>
+            <member><type>VkSurfaceKHR</type>                     <name>surface</name><comment>The swapchain's target surface</comment></member>
+            <member><type>uint32_t</type>                         <name>minImageCount</name><comment>Minimum number of presentation images the application needs</comment></member>
+            <member><type>VkFormat</type>                         <name>imageFormat</name><comment>Format of the presentation images</comment></member>
+            <member><type>VkColorSpaceKHR</type>                  <name>imageColorSpace</name><comment>Colorspace of the presentation images</comment></member>
+            <member><type>VkExtent2D</type>                       <name>imageExtent</name><comment>Dimensions of the presentation images</comment></member>
+            <member><type>uint32_t</type>                         <name>imageArrayLayers</name><comment>Determines the number of views for multiview/stereo presentation</comment></member>
+            <member><type>VkImageUsageFlags</type>                <name>imageUsage</name><comment>Bits indicating how the presentation images will be used</comment></member>
+            <member><type>VkSharingMode</type>                    <name>imageSharingMode</name><comment>Sharing mode used for the presentation images</comment></member>
+            <member optional="true"><type>uint32_t</type>         <name>queueFamilyIndexCount</name><comment>Number of queue families having access to the images in case of concurrent sharing mode</comment></member>
+            <member noautovalidity="true" len="queueFamilyIndexCount">const <type>uint32_t</type>*                  <name>pQueueFamilyIndices</name><comment>Array of queue family indices having access to the images in case of concurrent sharing mode</comment></member>
+            <member><type>VkSurfaceTransformFlagBitsKHR</type>    <name>preTransform</name><comment>The transform, relative to the device's natural orientation, applied to the image content prior to presentation</comment></member>
+            <member><type>VkCompositeAlphaFlagBitsKHR</type>      <name>compositeAlpha</name><comment>The alpha blending mode used when compositing this surface with other surfaces in the window system</comment></member>
+            <member><type>VkPresentModeKHR</type>                 <name>presentMode</name><comment>Which presentation mode to use for presents on this swap chain</comment></member>
+            <member><type>VkBool32</type>                         <name>clipped</name><comment>Specifies whether presentable images may be affected by window clip regions</comment></member>
+            <member optional="true"><type>VkSwapchainKHR</type>   <name>oldSwapchain</name><comment>Existing swap chain to replace, if any</comment></member>
         </type>
         <type category="struct" name="VkPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PRESENT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member optional="true"><type>uint32_t</type>         <name>waitSemaphoreCount</name></member>       <!-- Number of semaphores to wait for before presenting -->
-            <member optional="true" len="waitSemaphoreCount">const <type>VkSemaphore</type>* <name>pWaitSemaphores</name></member> <!-- Semaphores to wait for before presenting -->
-            <member><type>uint32_t</type>                         <name>swapchainCount</name></member>           <!-- Number of swap chains to present in this call -->
-            <member len="swapchainCount">const <type>VkSwapchainKHR</type>* <name>pSwapchains</name></member>    <!-- Swapchains to present an image from -->
-            <member len="swapchainCount">const <type>uint32_t</type>* <name>pImageIndices</name></member>        <!-- Indices of which swapchain images to present -->
-            <member optional="true" len="swapchainCount"><type>VkResult</type>* <name>pResults</name></member>   <!-- Optional (i.e. if non-NULL) VkResult for each swapchain -->
+            <member>const <type>void</type>*  <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>         <name>waitSemaphoreCount</name><comment>Number of semaphores to wait for before presenting</comment></member>
+            <member len="waitSemaphoreCount">const <type>VkSemaphore</type>* <name>pWaitSemaphores</name><comment>Semaphores to wait for before presenting</comment></member>
+            <member><type>uint32_t</type>                         <name>swapchainCount</name><comment>Number of swapchains to present in this call</comment></member>
+            <member len="swapchainCount">const <type>VkSwapchainKHR</type>* <name>pSwapchains</name><comment>Swapchains to present an image from</comment></member>
+            <member len="swapchainCount">const <type>uint32_t</type>* <name>pImageIndices</name><comment>Indices of which presentable images to present</comment></member>
+            <member optional="true" len="swapchainCount"><type>VkResult</type>* <name>pResults</name><comment>Optional (i.e. if non-NULL) VkResult for each swapchain</comment></member>
         </type>
-        <type category="struct" name="VkDebugReportCallbackCreateInfoEXT">
+        <type category="struct" name="VkDebugReportCallbackCreateInfoEXT" structextends="VkInstanceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member><type>VkDebugReportFlagsEXT</type>            <name>flags</name></member>                    <!-- Indicates which events call this callback-->
-            <member><type>PFN_vkDebugReportCallbackEXT</type>     <name>pfnCallback</name></member>              <!-- Function pointer of a callback function-->
-            <member optional="true"><type>void</type>*            <name>pUserData</name></member>                <!-- User data provided to callback function -->
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkDebugReportFlagsEXT</type>            <name>flags</name><comment>Indicates which events call this callback</comment></member>
+            <member><type>PFN_vkDebugReportCallbackEXT</type>     <name>pfnCallback</name><comment>Function pointer of a callback function</comment></member>
+            <member optional="true"><type>void</type>*            <name>pUserData</name><comment>User data provided to callback function</comment></member>
         </type>
-        <type category="struct" name="VkValidationFlagsEXT">
-            <member><type>VkStructureType</type>                  <name>sType</name></member>                    <!-- Must be VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT -->
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member><type>uint32_t</type>                         <name>disabledValidationCheckCount</name></member>   <!-- Number of validation checks to disable -->
-            <member len="disabledValidationCheckCount"><type>VkValidationCheckEXT</type>* <name>pDisabledValidationChecks</name></member>   <!-- Validation checks to disable -->
+        <type category="struct" name="VkValidationFlagsEXT" structextends="VkInstanceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT"><type>VkStructureType</type>                  <name>sType</name><comment>Must be VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT</comment></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>disabledValidationCheckCount</name><comment>Number of validation checks to disable</comment></member>
+            <member len="disabledValidationCheckCount"><type>VkValidationCheckEXT</type>* <name>pDisabledValidationChecks</name><comment>Validation checks to disable</comment></member>
         </type>
-        <type category="struct" name="VkPipelineRasterizationStateRasterizationOrderAMD">
+        <type category="struct" name="VkPipelineRasterizationStateRasterizationOrderAMD" structextends="VkPipelineRasterizationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member><type>VkRasterizationOrderAMD</type>          <name>rasterizationOrder</name></member>       <!-- Rasterization order to use for the pipeline -->
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkRasterizationOrderAMD</type>          <name>rasterizationOrder</name><comment>Rasterization order to use for the pipeline</comment></member>
         </type>
         <type category="struct" name="VkDebugMarkerObjectNameInfoEXT">
             <member values="VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member><type>VkDebugReportObjectTypeEXT</type>       <name>objectType</name></member>               <!-- The type of the object -->
-            <member><type>uint64_t</type>                         <name>object</name></member>                   <!-- The handle of the object, cast to uint64_t -->
-            <member len="null-terminated">const <type>char</type>* <name>pObjectName</name></member>             <!-- Name to apply to the object -->
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkDebugReportObjectTypeEXT</type>       <name>objectType</name><comment>The type of the object</comment></member>
+            <member><type>uint64_t</type>                         <name>object</name><comment>The handle of the object, cast to uint64_t</comment></member>
+            <member len="null-terminated">const <type>char</type>* <name>pObjectName</name><comment>Name to apply to the object</comment></member>
         </type>
         <type category="struct" name="VkDebugMarkerObjectTagInfoEXT">
             <member values="VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member><type>VkDebugReportObjectTypeEXT</type>       <name>objectType</name></member>               <!-- The type of the object -->
-            <member><type>uint64_t</type>                         <name>object</name></member>                   <!-- The handle of the object, cast to uint64_t -->
-            <member><type>uint64_t</type>                         <name>tagName</name></member>                  <!-- The name of the tag to set on the object -->
-            <member><type>size_t</type>                           <name>tagSize</name></member>                  <!-- The length in bytes of the tag data -->
-            <member len="tagSize">const <type>void</type>*        <name>pTag</name></member>                     <!-- Tag data to attach to the object -->
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkDebugReportObjectTypeEXT</type>       <name>objectType</name><comment>The type of the object</comment></member>
+            <member><type>uint64_t</type>                         <name>object</name><comment>The handle of the object, cast to uint64_t</comment></member>
+            <member><type>uint64_t</type>                         <name>tagName</name><comment>The name of the tag to set on the object</comment></member>
+            <member><type>size_t</type>                           <name>tagSize</name><comment>The length in bytes of the tag data</comment></member>
+            <member len="tagSize">const <type>void</type>*        <name>pTag</name><comment>Tag data to attach to the object</comment></member>
         </type>
         <type category="struct" name="VkDebugMarkerMarkerInfoEXT">
             <member values="VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member len="null-terminated">const <type>char</type>* <name>pMarkerName</name></member>             <!-- Name of the debug marker -->
-            <member optional="true"><type>float</type>            <name>color</name>[4]</member>                 <!-- Optional color for debug marker -->
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member len="null-terminated">const <type>char</type>* <name>pMarkerName</name><comment>Name of the debug marker</comment></member>
+            <member optional="true"><type>float</type>            <name>color</name>[4]<comment>Optional color for debug marker</comment></member>
         </type>
-        <type category="struct" name="VkDedicatedAllocationImageCreateInfoNV">
+        <type category="struct" name="VkDedicatedAllocationImageCreateInfoNV" structextends="VkImageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member><type>VkBool32</type>                         <name>dedicatedAllocation</name></member>      <!-- Whether this image uses a dedicated allocation -->
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>dedicatedAllocation</name><comment>Whether this image uses a dedicated allocation</comment></member>
         </type>
-        <type category="struct" name="VkDedicatedAllocationBufferCreateInfoNV">
+        <type category="struct" name="VkDedicatedAllocationBufferCreateInfoNV" structextends="VkBufferCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member><type>VkBool32</type>                         <name>dedicatedAllocation</name></member>      <!-- Whether this buffer uses a dedicated allocation -->
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>dedicatedAllocation</name><comment>Whether this buffer uses a dedicated allocation</comment></member>
         </type>
-        <type category="struct" name="VkDedicatedAllocationMemoryAllocateInfoNV">
+        <type category="struct" name="VkDedicatedAllocationMemoryAllocateInfoNV" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member optional="true"><type>VkImage</type>          <name>image</name></member>                    <!-- Image that this allocation will be bound to -->
-            <member optional="true"><type>VkBuffer</type>         <name>buffer</name></member>                   <!-- Buffer that this allocation will be bound to -->
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkImage</type>          <name>image</name><comment>Image that this allocation will be bound to</comment></member>
+            <member optional="true"><type>VkBuffer</type>         <name>buffer</name><comment>Buffer that this allocation will be bound to</comment></member>
         </type>
         <type category="struct" name="VkExternalImageFormatPropertiesNV" returnedonly="true">
             <member><type>VkImageFormatProperties</type>          <name>imageFormatProperties</name></member>
@@ -1587,31 +1647,31 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member optional="true"><type>VkExternalMemoryHandleTypeFlagsNV</type> <name>exportFromImportedHandleTypes</name></member>
             <member optional="true"><type>VkExternalMemoryHandleTypeFlagsNV</type> <name>compatibleHandleTypes</name></member>
         </type>
-        <type category="struct" name="VkExternalMemoryImageCreateInfoNV">
+        <type category="struct" name="VkExternalMemoryImageCreateInfoNV" structextends="VkImageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalMemoryHandleTypeFlagsNV</type> <name>handleTypes</name></member>
         </type>
-        <type category="struct" name="VkExportMemoryAllocateInfoNV">
+        <type category="struct" name="VkExportMemoryAllocateInfoNV" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalMemoryHandleTypeFlagsNV</type> <name>handleTypes</name></member>
         </type>
-        <type category="struct" name="VkImportMemoryWin32HandleInfoNV">
+        <type category="struct" name="VkImportMemoryWin32HandleInfoNV" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalMemoryHandleTypeFlagsNV</type> <name>handleType</name></member>
             <member optional="true"><type>HANDLE</type>                           <name>handle</name></member>
         </type>
-        <type category="struct" name="VkExportMemoryWin32HandleInfoNV">
+        <type category="struct" name="VkExportMemoryWin32HandleInfoNV" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true">const <type>SECURITY_ATTRIBUTES</type>*       <name>pAttributes</name></member>
             <member optional="true"><type>DWORD</type>                            <name>dwAccess</name></member>
         </type>
-        <type category="struct" name="VkWin32KeyedMutexAcquireReleaseInfoNV">
+        <type category="struct" name="VkWin32KeyedMutexAcquireReleaseInfoNV" structextends="VkSubmitInfo">
             <member values="VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>                         <name>acquireCount</name></member>
             <member len="acquireCount">const <type>VkDeviceMemory</type>*            <name>pAcquireSyncs</name></member>
             <member len="acquireCount">const <type>uint64_t</type>*                  <name>pAcquireKeys</name></member>
@@ -1620,7 +1680,6 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member len="releaseCount">const <type>VkDeviceMemory</type>*            <name>pReleaseSyncs</name></member>
             <member len="releaseCount">const <type>uint64_t</type>*                  <name>pReleaseKeys</name></member>
         </type>
-
         <type category="struct" name="VkDeviceGeneratedCommandsFeaturesNVX">
             <member values="VK_STRUCTURE_TYPE_DEVICE_GENERATED_COMMANDS_FEATURES_NVX"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
@@ -1637,14 +1696,14 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkIndirectCommandsTokenNVX">
             <member><type>VkIndirectCommandsTokenTypeNVX</type>      <name>tokenType</name></member>
-            <member><type>VkBuffer</type>                         <name>buffer</name></member>  <!-- buffer containing tableEntries and additional data for indirectCommands -->
-            <member><type>VkDeviceSize</type>                     <name>offset</name></member>  <!-- offset from the base address of the buffer -->
+            <member><type>VkBuffer</type>                         <name>buffer</name><comment>buffer containing tableEntries and additional data for indirectCommands</comment></member>
+            <member><type>VkDeviceSize</type>                     <name>offset</name><comment>offset from the base address of the buffer</comment></member>
         </type>
         <type category="struct" name="VkIndirectCommandsLayoutTokenNVX">
             <member><type>VkIndirectCommandsTokenTypeNVX</type>      <name>tokenType</name></member>
-            <member><type>uint32_t</type>                         <name>bindingUnit</name></member>  <!-- Binding unit for vertex attribute / descriptor set, offset for pushconstants -->
-            <member><type>uint32_t</type>                         <name>dynamicCount</name></member> <!-- Number of variable dynamic values for descriptor set / push constants -->
-            <member><type>uint32_t</type>                         <name>divisor</name></member>      <!-- Rate the which the array is advanced per element (must be power of 2, minimum 1) -->
+            <member><type>uint32_t</type>                         <name>bindingUnit</name><comment>Binding unit for vertex attribute / descriptor set, offset for pushconstants</comment></member>
+            <member><type>uint32_t</type>                         <name>dynamicCount</name><comment>Number of variable dynamic values for descriptor set / push constants</comment></member>
+            <member><type>uint32_t</type>                         <name>divisor</name><comment>Rate the which the array is advanced per element (must be power of 2, minimum 1)</comment></member>
         </type>
         <type category="struct" name="VkIndirectCommandsLayoutCreateInfoNVX">
             <member values="VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NVX"><type>VkStructureType</type> <name>sType</name></member>
@@ -1713,6 +1772,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member><type>VkObjectEntryTypeNVX</type>         <name>type</name></member>
             <member><type>VkObjectEntryUsageFlagsNVX</type>   <name>flags</name></member>
             <member><type>VkBuffer</type>                     <name>buffer</name></member>
+            <member><type>VkIndexType</type>                  <name>indexType</name></member>
         </type>
         <type category="struct" name="VkObjectTablePushConstantEntryNVX">
             <member><type>VkObjectEntryTypeNVX</type>         <name>type</name></member>
@@ -1720,18 +1780,710 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member><type>VkPipelineLayout</type>             <name>pipelineLayout</name></member>
             <member><type>VkShaderStageFlags</type>           <name>stageFlags</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceFeatures2KHR" structextends="VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkPhysicalDeviceFeatures</type>         <name>features</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceProperties2KHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkPhysicalDeviceProperties</type>       <name>properties</name></member>
+        </type>
+        <type category="struct" name="VkFormatProperties2KHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkFormatProperties</type>               <name>formatProperties</name></member>
+        </type>
+        <type category="struct" name="VkImageFormatProperties2KHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>* <name>pNext</name></member>
+            <member><type>VkImageFormatProperties</type>          <name>imageFormatProperties</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceImageFormatInfo2KHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>* <name>pNext</name></member>
+            <member><type>VkFormat</type>                         <name>format</name></member>
+            <member><type>VkImageType</type>                      <name>type</name></member>
+            <member><type>VkImageTiling</type>                    <name>tiling</name></member>
+            <member><type>VkImageUsageFlags</type>                <name>usage</name></member>
+            <member optional="true"><type>VkImageCreateFlags</type> <name>flags</name></member>
+        </type>
+        <type category="struct" name="VkQueueFamilyProperties2KHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkQueueFamilyProperties</type>          <name>queueFamilyProperties</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceMemoryProperties2KHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkPhysicalDeviceMemoryProperties</type> <name>memoryProperties</name></member>
+        </type>
+        <type category="struct" name="VkSparseImageFormatProperties2KHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkSparseImageFormatProperties</type>    <name>properties</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceSparseImageFormatInfo2KHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkFormat</type>                         <name>format</name></member>
+            <member><type>VkImageType</type>                      <name>type</name></member>
+            <member><type>VkSampleCountFlagBits</type>            <name>samples</name></member>
+            <member><type>VkImageUsageFlags</type>                <name>usage</name></member>
+            <member><type>VkImageTiling</type>                    <name>tiling</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDevicePushDescriptorPropertiesKHR" structextends="VkPhysicalDeviceProperties2KHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>maxPushDescriptors</name></member>
+        </type>
+        <type category="struct" name="VkPresentRegionsKHR" structextends="VkPresentInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*  <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>swapchainCount</name><comment>Copy of VkPresentInfoKHR::swapchainCount</comment></member>
+            <member len="swapchainCount" optional="true">const <type>VkPresentRegionKHR</type>*   <name>pRegions</name><comment>The regions that have changed</comment></member>
+        </type>
+        <type category="struct" name="VkPresentRegionKHR">
+            <member optional="true"><type>uint32_t</type>         <name>rectangleCount</name><comment>Number of rectangles in pRectangles</comment></member>
+            <member optional="true" len="rectangleCount">const <type>VkRectLayerKHR</type>*   <name>pRectangles</name><comment>Array of rectangles that have changed in a swapchain's image(s)</comment></member>
+        </type>
+        <type category="struct" name="VkRectLayerKHR">
+            <member><type>VkOffset2D</type>                       <name>offset</name><comment>upper-left corner of a rectangle that has not changed, in pixels of a presentation images</comment></member>
+            <member><type>VkExtent2D</type>                       <name>extent</name><comment>Dimensions of a rectangle that has not changed, in pixels of a presentation images</comment></member>
+            <member><type>uint32_t</type>                         <name>layer</name><comment>Layer of a swapchain's image(s), for stereoscopic-3D images</comment></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceVariablePointerFeaturesKHR" structextends="VkPhysicalDeviceFeatures2KHR,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>variablePointersStorageBuffer</name></member>
+            <member><type>VkBool32</type>                         <name>variablePointers</name></member>
+        </type>
+        <type category="struct" name="VkExternalMemoryPropertiesKHR" returnedonly="true">
+            <member><type>VkExternalMemoryFeatureFlagsKHR</type>  <name>externalMemoryFeatures</name></member>
+            <member optional="true"><type>VkExternalMemoryHandleTypeFlagsKHR</type> <name>exportFromImportedHandleTypes</name></member>
+            <member><type>VkExternalMemoryHandleTypeFlagsKHR</type> <name>compatibleHandleTypes</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceExternalImageFormatInfoKHR"  structextends="VkPhysicalDeviceImageFormatInfo2KHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+        </type>
+        <type category="struct" name="VkExternalImageFormatPropertiesKHR" returnedonly="true" structextends="VkImageFormatProperties2KHR">
+            <member values="VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkExternalMemoryPropertiesKHR</type> <name>externalMemoryProperties</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceExternalBufferInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkBufferCreateFlags</type> <name>flags</name></member>
+            <member><type>VkBufferUsageFlags</type>               <name>usage</name></member>
+            <member><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+        </type>
+        <type category="struct" name="VkExternalBufferPropertiesKHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkExternalMemoryPropertiesKHR</type>    <name>externalMemoryProperties</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceIDPropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2KHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>uint8_t</type>                          <name>deviceUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
+            <member><type>uint8_t</type>                          <name>driverUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
+            <member><type>uint8_t</type>                          <name>deviceLUID</name>[<enum>VK_LUID_SIZE_KHR</enum>]</member>
+            <member><type>uint32_t</type>                         <name>deviceNodeMask</name></member>
+            <member><type>VkBool32</type>                         <name>deviceLUIDValid</name></member>
+        </type>
+        <type category="struct" name="VkExternalMemoryImageCreateInfoKHR" structextends="VkImageCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkExternalMemoryHandleTypeFlagsKHR</type> <name>handleTypes</name></member>
+        </type>
+        <type category="struct" name="VkExternalMemoryBufferCreateInfoKHR" structextends="VkBufferCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkExternalMemoryHandleTypeFlagsKHR</type> <name>handleTypes</name></member>
+        </type>
+        <type category="struct" name="VkExportMemoryAllocateInfoKHR" structextends="VkMemoryAllocateInfo">
+            <member values="VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkExternalMemoryHandleTypeFlagsKHR</type> <name>handleTypes</name></member>
+        </type>
+        <type category="struct" name="VkImportMemoryWin32HandleInfoKHR" structextends="VkMemoryAllocateInfo">
+            <member values="VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member optional="true"><type>HANDLE</type>           <name>handle</name></member>
+            <member optional="true"><type>LPCWSTR</type>          <name>name</name></member>
+        </type>
+        <type category="struct" name="VkExportMemoryWin32HandleInfoKHR" structextends="VkMemoryAllocateInfo">
+            <member values="VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>SECURITY_ATTRIBUTES</type>* <name>pAttributes</name></member>
+            <member><type>DWORD</type>                            <name>dwAccess</name></member>
+            <member><type>LPCWSTR</type>                          <name>name</name></member>
+        </type>
+        <type category="struct" name="VkMemoryWin32HandlePropertiesKHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>memoryTypeBits</name></member>
+        </type>
+        <type category="struct" name="VkMemoryGetWin32HandleInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkDeviceMemory</type>                   <name>memory</name></member>
+            <member><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+        </type>
+        <type category="struct" name="VkImportMemoryFdInfoKHR" structextends="VkMemoryAllocateInfo">
+            <member values="VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member><type>int</type>                              <name>fd</name></member>
+        </type>
+        <type category="struct" name="VkMemoryFdPropertiesKHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>memoryTypeBits</name></member>
+        </type>
+        <type category="struct" name="VkMemoryGetFdInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkDeviceMemory</type>                   <name>memory</name></member>
+            <member><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+        </type>
+        <type category="struct" name="VkWin32KeyedMutexAcquireReleaseInfoKHR" structextends="VkSubmitInfo">
+            <member values="VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>         <name>acquireCount</name></member>
+            <member len="acquireCount">const <type>VkDeviceMemory</type>* <name>pAcquireSyncs</name></member>
+            <member len="acquireCount">const <type>uint64_t</type>* <name>pAcquireKeys</name></member>
+            <member len="acquireCount">const <type>uint32_t</type>* <name>pAcquireTimeouts</name></member>
+            <member optional="true"><type>uint32_t</type>         <name>releaseCount</name></member>
+            <member len="releaseCount">const <type>VkDeviceMemory</type>* <name>pReleaseSyncs</name></member>
+            <member len="releaseCount">const <type>uint64_t</type>* <name>pReleaseKeys</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceExternalSemaphoreInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkExternalSemaphoreHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+        </type>
+        <type category="struct" name="VkExternalSemaphorePropertiesKHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkExternalSemaphoreHandleTypeFlagsKHR</type> <name>exportFromImportedHandleTypes</name></member>
+            <member><type>VkExternalSemaphoreHandleTypeFlagsKHR</type> <name>compatibleHandleTypes</name></member>
+            <member optional="true"><type>VkExternalSemaphoreFeatureFlagsKHR</type> <name>externalSemaphoreFeatures</name></member>
+        </type>
+        <type category="struct" name="VkExportSemaphoreCreateInfoKHR" structextends="VkSemaphoreCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkExternalSemaphoreHandleTypeFlagsKHR</type> <name>handleTypes</name></member>
+        </type>
+        <type category="struct" name="VkImportSemaphoreWin32HandleInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member externsync="true"><type>VkSemaphore</type>    <name>semaphore</name></member>
+            <member optional="true"><type>VkSemaphoreImportFlagsKHR</type> <name>flags</name></member>
+            <member optional="true"><type>VkExternalSemaphoreHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member optional="true"><type>HANDLE</type>           <name>handle</name></member>
+            <member optional="true"><type>LPCWSTR</type>          <name>name</name></member>
+        </type>
+        <type category="struct" name="VkExportSemaphoreWin32HandleInfoKHR" structextends="VkSemaphoreCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>SECURITY_ATTRIBUTES</type>*       <name>pAttributes</name></member>
+            <member><type>DWORD</type>                            <name>dwAccess</name></member>
+            <member><type>LPCWSTR</type>                          <name>name</name></member>
+        </type>
+        <type category="struct" name="VkD3D12FenceSubmitInfoKHR" structextends="VkSubmitInfo">
+            <member values="VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>         <name>waitSemaphoreValuesCount</name></member>
+            <member optional="true" len="waitSemaphoreValuesCount">const <type>uint64_t</type>* <name>pWaitSemaphoreValues</name></member>
+            <member optional="true"><type>uint32_t</type>         <name>signalSemaphoreValuesCount</name></member>
+            <member optional="true" len="signalSemaphoreValuesCount">const <type>uint64_t</type>* <name>pSignalSemaphoreValues</name></member>
+        </type>
+        <type category="struct" name="VkSemaphoreGetWin32HandleInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkSemaphore</type>                      <name>semaphore</name></member>
+            <member><type>VkExternalSemaphoreHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+        </type>
+        <type category="struct" name="VkImportSemaphoreFdInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member externsync="true"><type>VkSemaphore</type>    <name>semaphore</name></member>
+            <member optional="true"><type>VkSemaphoreImportFlagsKHR</type> <name>flags</name></member>
+            <member><type>VkExternalSemaphoreHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member><type>int</type>                              <name>fd</name></member>
+        </type>
+        <type category="struct" name="VkSemaphoreGetFdInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkSemaphore</type>                      <name>semaphore</name></member>
+            <member><type>VkExternalSemaphoreHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceExternalFenceInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkExternalFenceHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+        </type>
+        <type category="struct" name="VkExternalFencePropertiesKHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkExternalFenceHandleTypeFlagsKHR</type> <name>exportFromImportedHandleTypes</name></member>
+            <member><type>VkExternalFenceHandleTypeFlagsKHR</type> <name>compatibleHandleTypes</name></member>
+            <member optional="true"><type>VkExternalFenceFeatureFlagsKHR</type> <name>externalFenceFeatures</name></member>
+        </type>
+        <type category="struct" name="VkExportFenceCreateInfoKHR" structextends="VkFenceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkExternalFenceHandleTypeFlagsKHR</type> <name>handleTypes</name></member>
+        </type>
+        <type category="struct" name="VkImportFenceWin32HandleInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_IMPORT_FENCE_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                                        <name>pNext</name></member>
+            <member externsync="true"><type>VkFence</type>                          <name>fence</name></member>
+            <member optional="true"><type>VkFenceImportFlagsKHR</type>              <name>flags</name></member>
+            <member optional="true"><type>VkExternalFenceHandleTypeFlagBitsKHR</type>  <name>handleType</name></member>
+            <member optional="true"><type>HANDLE</type>                             <name>handle</name></member>
+            <member optional="true"><type>LPCWSTR</type>                            <name>name</name></member>
+        </type>
+        <type category="struct" name="VkExportFenceWin32HandleInfoKHR" structextends="VkFenceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_EXPORT_FENCE_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                                <name>pNext</name></member>
+            <member optional="true">const <type>SECURITY_ATTRIBUTES</type>* <name>pAttributes</name></member>
+            <member><type>DWORD</type>                                      <name>dwAccess</name></member>
+            <member><type>LPCWSTR</type>                                    <name>name</name></member>
+        </type>
+        <type category="struct" name="VkFenceGetWin32HandleInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_FENCE_GET_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkFence</type>                                <name>fence</name></member>
+            <member><type>VkExternalFenceHandleTypeFlagBitsKHR</type>   <name>handleType</name></member>
+        </type>
+        <type category="struct" name="VkImportFenceFdInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_IMPORT_FENCE_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member externsync="true"><type>VkFence</type>              <name>fence</name></member>
+            <member optional="true"><type>VkFenceImportFlagsKHR</type>  <name>flags</name></member>
+            <member><type>VkExternalFenceHandleTypeFlagBitsKHR</type>   <name>handleType</name></member>
+            <member><type>int</type>                                    <name>fd</name></member>
+        </type>
+        <type category="struct" name="VkFenceGetFdInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkFence</type>                                <name>fence</name></member>
+            <member><type>VkExternalFenceHandleTypeFlagBitsKHR</type>   <name>handleType</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceMultiviewFeaturesKHX" structextends="VkPhysicalDeviceFeatures2KHR,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true"><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>multiview</name><comment>Multiple views in a renderpass</comment></member>
+            <member><type>VkBool32</type>                         <name>multiviewGeometryShader</name><comment>Multiple views in a renderpass w/ geometry shader</comment></member>
+            <member><type>VkBool32</type>                         <name>multiviewTessellationShader</name><comment>Multiple views in a renderpass w/ tessellation shader</comment></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceMultiviewPropertiesKHX" returnedonly="true" structextends="VkPhysicalDeviceProperties2KHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>maxMultiviewViewCount</name><comment>max number of views in a subpass</comment></member>
+            <member><type>uint32_t</type>                         <name>maxMultiviewInstanceIndex</name><comment>max instance index for a draw in a multiview subpass</comment></member>
+        </type>
+        <type category="struct" name="VkRenderPassMultiviewCreateInfoKHX" structextends="VkRenderPassCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO_KHX"><type>VkStructureType</type>        <name>sType</name></member>
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>               <name>subpassCount</name></member>
+            <member len="subpassCount">const <type>uint32_t</type>*     <name>pViewMasks</name></member>
+            <member optional="true"><type>uint32_t</type>               <name>dependencyCount</name></member>
+            <member len="dependencyCount">const <type>int32_t</type>*   <name>pViewOffsets</name></member>
+            <member optional="true"><type>uint32_t</type>               <name>correlationMaskCount</name></member>
+            <member len="correlationMaskCount">const <type>uint32_t</type>* <name>pCorrelationMasks</name></member>
+        </type>
+        <type category="struct" name="VkSurfaceCapabilities2EXT" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES2_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>minImageCount</name><comment>Supported minimum number of images for the surface</comment></member>
+            <member><type>uint32_t</type>                         <name>maxImageCount</name><comment>Supported maximum number of images for the surface, 0 for unlimited</comment></member>
+            <member><type>VkExtent2D</type>                       <name>currentExtent</name><comment>Current image width and height for the surface, (0, 0) if undefined</comment></member>
+            <member><type>VkExtent2D</type>                       <name>minImageExtent</name><comment>Supported minimum image width and height for the surface</comment></member>
+            <member><type>VkExtent2D</type>                       <name>maxImageExtent</name><comment>Supported maximum image width and height for the surface</comment></member>
+            <member><type>uint32_t</type>                         <name>maxImageArrayLayers</name><comment>Supported maximum number of image layers for the surface</comment></member>
+            <member optional="true"><type>VkSurfaceTransformFlagsKHR</type>       <name>supportedTransforms</name><comment>1 or more bits representing the transforms supported</comment></member>
+            <member><type>VkSurfaceTransformFlagBitsKHR</type>    <name>currentTransform</name><comment>The surface's current transform relative to the device's natural orientation</comment></member>
+            <member optional="true"><type>VkCompositeAlphaFlagsKHR</type>         <name>supportedCompositeAlpha</name><comment>1 or more bits representing the alpha compositing modes supported</comment></member>
+            <member optional="true"><type>VkImageUsageFlags</type>                <name>supportedUsageFlags</name><comment>Supported image usage flags for the surface</comment></member>
+            <member optional="true"><type>VkSurfaceCounterFlagsEXT</type> <name>supportedSurfaceCounters</name></member>
+        </type>
+        <type category="struct" name="VkDisplayPowerInfoEXT">
+            <member values="VK_STRUCTURE_TYPE_DISPLAY_POWER_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkDisplayPowerStateEXT</type>           <name>powerState</name></member>
+        </type>
+        <type category="struct" name="VkDeviceEventInfoEXT">
+            <member values="VK_STRUCTURE_TYPE_DEVICE_EVENT_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkDeviceEventTypeEXT</type>             <name>deviceEvent</name></member>
+        </type>
+        <type category="struct" name="VkDisplayEventInfoEXT">
+            <member values="VK_STRUCTURE_TYPE_DISPLAY_EVENT_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkDisplayEventTypeEXT</type>            <name>displayEvent</name></member>
+        </type>
+        <type category="struct" name="VkSwapchainCounterCreateInfoEXT" structextends="VkSwapchainCreateInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_SWAPCHAIN_COUNTER_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkSurfaceCounterFlagsEXT</type>         <name>surfaceCounters</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceGroupPropertiesKHX" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>physicalDeviceCount</name></member>
+            <member><type>VkPhysicalDevice</type>                 <name>physicalDevices</name>[<enum>VK_MAX_DEVICE_GROUP_SIZE_KHX</enum>]</member>
+            <member><type>VkBool32</type>                         <name>subsetAllocation</name></member>
+        </type>
+        <type category="struct" name="VkMemoryAllocateFlagsInfoKHX" structextends="VkMemoryAllocateInfo">
+            <member values="VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkMemoryAllocateFlagsKHX</type> <name>flags</name></member>
+            <member><type>uint32_t</type>                         <name>deviceMask</name></member>
+        </type>
+        <type category="struct" name="VkBindBufferMemoryInfoKHX">
+            <member values="VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_INFO_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkBuffer</type>                         <name>buffer</name></member>
+            <member><type>VkDeviceMemory</type>                   <name>memory</name></member>
+            <member><type>VkDeviceSize</type>                     <name>memoryOffset</name></member>
+            <member optional="true"><type>uint32_t</type>         <name>deviceIndexCount</name></member>
+            <member len="deviceIndexCount">const <type>uint32_t</type>*  <name>pDeviceIndices</name></member>
+        </type>
+        <type category="struct" name="VkBindImageMemoryInfoKHX">
+            <member values="VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkImage</type>                          <name>image</name></member>
+            <member><type>VkDeviceMemory</type>                   <name>memory</name></member>
+            <member><type>VkDeviceSize</type>                     <name>memoryOffset</name></member>
+            <member optional="true"><type>uint32_t</type>         <name>deviceIndexCount</name></member>
+            <member len="deviceIndexCount">const <type>uint32_t</type>*  <name>pDeviceIndices</name></member>
+            <member optional="true"><type>uint32_t</type>         <name>SFRRectCount</name></member>
+            <member len="SFRRectCount">const <type>VkRect2D</type>*  <name>pSFRRects</name></member>
+        </type>
+        <type category="struct" name="VkDeviceGroupRenderPassBeginInfoKHX" structextends="VkRenderPassBeginInfo">
+            <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_RENDER_PASS_BEGIN_INFO_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>deviceMask</name></member>
+            <member optional="true"><type>uint32_t</type>         <name>deviceRenderAreaCount</name></member>
+            <member len="deviceRenderAreaCount">const <type>VkRect2D</type>*  <name>pDeviceRenderAreas</name></member>
+        </type>
+        <type category="struct" name="VkDeviceGroupCommandBufferBeginInfoKHX" structextends="VkCommandBufferBeginInfo">
+            <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_COMMAND_BUFFER_BEGIN_INFO_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>deviceMask</name></member>
+        </type>
+        <type category="struct" name="VkDeviceGroupSubmitInfoKHX" structextends="VkSubmitInfo">
+            <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_SUBMIT_INFO_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>         <name>waitSemaphoreCount</name></member>
+            <member len="waitSemaphoreCount">const <type>uint32_t</type>*    <name>pWaitSemaphoreDeviceIndices</name></member>
+            <member optional="true"><type>uint32_t</type>         <name>commandBufferCount</name></member>
+            <member len="commandBufferCount">const <type>uint32_t</type>*    <name>pCommandBufferDeviceMasks</name></member>
+            <member optional="true"><type>uint32_t</type>         <name>signalSemaphoreCount</name></member>
+            <member len="signalSemaphoreCount">const <type>uint32_t</type>*  <name>pSignalSemaphoreDeviceIndices</name></member>
+        </type>
+        <type category="struct" name="VkDeviceGroupBindSparseInfoKHX" structextends="VkBindSparseInfo">
+            <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_BIND_SPARSE_INFO_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>resourceDeviceIndex</name></member>
+            <member><type>uint32_t</type>                         <name>memoryDeviceIndex</name></member>
+        </type>
+        <type category="struct" name="VkDeviceGroupPresentCapabilitiesKHX" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_CAPABILITIES_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>presentMask</name>[<enum>VK_MAX_DEVICE_GROUP_SIZE_KHX</enum>]</member>
+            <member><type>VkDeviceGroupPresentModeFlagsKHX</type> <name>modes</name></member>
+        </type>
+        <type category="struct" name="VkImageSwapchainCreateInfoKHX" structextends="VkImageCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_IMAGE_SWAPCHAIN_CREATE_INFO_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkSwapchainKHR</type>   <name>swapchain</name></member>
+        </type>
+        <type category="struct" name="VkBindImageMemorySwapchainInfoKHX" structextends="VkBindImageMemoryInfoKHX">
+            <member values="VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member externsync="true"><type>VkSwapchainKHR</type> <name>swapchain</name></member>
+            <member><type>uint32_t</type>                         <name>imageIndex</name></member>
+        </type>
+        <type category="struct" name="VkAcquireNextImageInfoKHX">
+            <member values="VK_STRUCTURE_TYPE_ACQUIRE_NEXT_IMAGE_INFO_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member externsync="true"><type>VkSwapchainKHR</type> <name>swapchain</name></member>
+            <member><type>uint64_t</type>                         <name>timeout</name></member>
+            <member optional="true" externsync="true"><type>VkSemaphore</type> <name>semaphore</name></member>
+            <member optional="true" externsync="true"><type>VkFence</type> <name>fence</name></member>
+            <member><type>uint32_t</type>                         <name>deviceMask</name></member>
+        </type>
+        <type category="struct" name="VkDeviceGroupPresentInfoKHX" structextends="VkPresentInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_INFO_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*  <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>         <name>swapchainCount</name></member>
+            <member len="swapchainCount">const <type>uint32_t</type>* <name>pDeviceMasks</name></member>
+            <member><type>VkDeviceGroupPresentModeFlagBitsKHX</type> <name>mode</name></member>
+        </type>
+        <type category="struct" name="VkDeviceGroupDeviceCreateInfoKHX" structextends="VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>                         <name>physicalDeviceCount</name></member>
+            <member len="physicalDeviceCount">const <type>VkPhysicalDevice</type>*  <name>pPhysicalDevices</name></member>
+        </type>
+        <type category="struct" name="VkDeviceGroupSwapchainCreateInfoKHX" structextends="VkSwapchainCreateInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_SWAPCHAIN_CREATE_INFO_KHX"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkDeviceGroupPresentModeFlagsKHX</type>                         <name>modes</name></member>
+        </type>
+        <type category="struct" name="VkDescriptorUpdateTemplateEntryKHR">
+            <member><type>uint32_t</type>                         <name>dstBinding</name><comment>Binding within the destination descriptor set to write</comment></member>
+            <member><type>uint32_t</type>                         <name>dstArrayElement</name><comment>Array element within the destination binding to write</comment></member>
+            <member><type>uint32_t</type>                         <name>descriptorCount</name><comment>Number of descriptors to write</comment></member>
+            <member><type>VkDescriptorType</type>                 <name>descriptorType</name><comment>Descriptor type to write</comment></member>
+            <member><type>size_t</type>                           <name>offset</name><comment>Offset into pData where the descriptors to update are stored</comment></member>
+            <member><type>size_t</type>                           <name>stride</name><comment>Stride between two descriptors in pData when writing more than one descriptor</comment></member>
+        </type>
+        <type category="struct" name="VkDescriptorUpdateTemplateCreateInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                                   <name>pNext</name></member>
+            <member optional="true"><type>VkDescriptorUpdateTemplateCreateFlagsKHR</type>    <name>flags</name></member>
+            <member><type>uint32_t</type>                 <name>descriptorUpdateEntryCount</name><comment>Number of descriptor update entries to use for the update template</comment></member>
+            <member len="descriptorUpdateEntryCount">const <type>VkDescriptorUpdateTemplateEntryKHR</type>* <name>pDescriptorUpdateEntries</name><comment>Descriptor update entries for the template</comment></member>
+            <member><type>VkDescriptorUpdateTemplateTypeKHR</type> <name>templateType</name></member>
+            <member optional="true"><type>VkDescriptorSetLayout</type> <name>descriptorSetLayout</name></member>
+            <member optional="true"><type>VkPipelineBindPoint</type> <name>pipelineBindPoint</name></member>
+            <member optional="true"><type>VkPipelineLayout</type><name>pipelineLayout</name><comment>If used for push descriptors, this is the only allowed layout</comment></member>
+            <member optional="true"><type>uint32_t</type> <name>set</name></member>
+        </type>
+        <type category="struct" name="VkXYColorEXT" comment="Chromaticity coordinate">
+            <member><type>float</type>   <name>x</name></member>
+            <member><type>float</type>   <name>y</name></member>
+        </type>
+        <type category="struct" name="VkHdrMetadataEXT">
+                <comment>Display primary in chromaticity coordinates</comment>
+            <member values="VK_STRUCTURE_TYPE_HDR_METADATA_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*    <name>pNext</name></member>
+                <comment> From SMPTE 2086</comment>
+            <member><type>VkXYColorEXT</type>   <name>displayPrimaryRed</name><comment>Display primary's Red</comment></member>
+            <member><type>VkXYColorEXT</type>   <name>displayPrimaryGreen</name><comment>Display primary's Green</comment></member>
+            <member><type>VkXYColorEXT</type>   <name>displayPrimaryBlue</name><comment>Display primary's Blue</comment></member>
+            <member><type>VkXYColorEXT</type>   <name>whitePoint</name><comment>Display primary's Blue</comment></member>
+            <member><type>float</type>          <name>maxLuminance</name><comment>Display maximum luminance</comment></member>
+            <member><type>float</type>          <name>minLuminance</name><comment>Display minimum luminance</comment></member>
+                <comment> From CTA 861.3</comment>
+            <member><type>float</type>          <name>maxContentLightLevel</name><comment>Content maximum luminance</comment></member>
+            <member><type>float</type>          <name>maxFrameAverageLightLevel</name></member>
+        </type>
+        <type category="struct" name="VkRefreshCycleDurationGOOGLE">
+            <member><type>uint64_t</type>                         <name>refreshDuration</name><comment>Number of nanoseconds from the start of one refresh cycle to the next</comment></member>
+        </type>
+        <type category="struct" name="VkPastPresentationTimingGOOGLE">
+            <member><type>uint32_t</type>                         <name>presentID</name><comment>Application-provided identifier, previously given to vkQueuePresentKHR</comment></member>
+            <member><type>uint64_t</type>                         <name>desiredPresentTime</name><comment>Earliest time an image should have been presented, previously given to vkQueuePresentKHR</comment></member>
+            <member><type>uint64_t</type>                         <name>actualPresentTime</name><comment>Time the image was actually displayed</comment></member>
+            <member><type>uint64_t</type>                         <name>earliestPresentTime</name><comment>Earliest time the image could have been displayed</comment></member>
+            <member><type>uint64_t</type>                         <name>presentMargin</name><comment>How early vkQueuePresentKHR was processed vs. how soon it needed to be and make earliestPresentTime</comment></member>
+        </type>
+        <type category="struct" name="VkPresentTimesInfoGOOGLE" structextends="VkPresentInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*  <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>swapchainCount</name><comment>Copy of VkPresentInfoKHR::swapchainCount</comment></member>
+            <member len="swapchainCount" optional="true">const <type>VkPresentTimeGOOGLE</type>*   <name>pTimes</name><comment>The earliest times to present images</comment></member>
+        </type>
+        <type category="struct" name="VkPresentTimeGOOGLE">
+            <member><type>uint32_t</type>                         <name>presentID</name><comment>Application-provided identifier</comment></member>
+            <member><type>uint64_t</type>                         <name>desiredPresentTime</name><comment>Earliest time an image should be presented</comment></member>
+        </type>
+        <type category="struct" name="VkIOSSurfaceCreateInfoMVK">
+            <member values="VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                                    <name>pNext</name></member>
+            <member optional="true"><type>VkIOSSurfaceCreateFlagsMVK</type>     <name>flags</name></member>
+            <member>const <type>void</type>*                                    <name>pView</name></member>
+        </type>
+        <type category="struct" name="VkMacOSSurfaceCreateInfoMVK">
+            <member values="VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                                    <name>pNext</name></member>
+            <member optional="true"><type>VkMacOSSurfaceCreateFlagsMVK</type>   <name>flags</name></member>
+            <member>const <type>void</type>*                                    <name>pView</name></member>
+        </type>
+        <type category="struct" name="VkViewportWScalingNV">
+            <member><type>float</type>          <name>xcoeff</name></member>
+            <member><type>float</type>          <name>ycoeff</name></member>
+        </type>
+        <type category="struct" name="VkPipelineViewportWScalingStateCreateInfoNV" structextends="VkPipelineViewportStateCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkBool32</type>               <name>viewportWScalingEnable</name></member>
+            <member><type>uint32_t</type>               <name>viewportCount</name></member>
+            <member noautovalidity="true" len="viewportCount">const <type>VkViewportWScalingNV</type>*      <name>pViewportWScalings</name></member>
+        </type>
+        <type category="struct" name="VkViewportSwizzleNV">
+            <member><type>VkViewportCoordinateSwizzleNV</type>          <name>x</name></member>
+            <member><type>VkViewportCoordinateSwizzleNV</type>          <name>y</name></member>
+            <member><type>VkViewportCoordinateSwizzleNV</type>          <name>z</name></member>
+            <member><type>VkViewportCoordinateSwizzleNV</type>          <name>w</name></member>
+        </type>
+        <type category="struct" name="VkPipelineViewportSwizzleStateCreateInfoNV" structextends="VkPipelineViewportStateCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineViewportSwizzleStateCreateFlagsNV</type>    <name>flags</name></member>
+            <member><type>uint32_t</type>               <name>viewportCount</name></member>
+            <member noautovalidity="true" optional="true" len="viewportCount">const <type>VkViewportSwizzleNV</type>*      <name>pViewportSwizzles</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceDiscardRectanglePropertiesEXT" structextends="VkPhysicalDeviceProperties2KHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                  <name>pNext</name></member>
+            <member><type>uint32_t</type>               <name>maxDiscardRectangles</name><comment>max number of active discard rectangles</comment></member>
+        </type>
+        <type category="struct" name="VkPipelineDiscardRectangleStateCreateInfoEXT" structextends="VkGraphicsPipelineCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                                                                      <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineDiscardRectangleStateCreateFlagsEXT</type>                    <name>flags</name></member>
+            <member><type>VkDiscardRectangleModeEXT</type>                                                        <name>discardRectangleMode</name></member>
+            <member optional="true"><type>uint32_t</type>                                                         <name>discardRectangleCount</name></member>
+            <member noautovalidity="true" optional="true" len="discardRectangleCount">const <type>VkRect2D</type>* <name>pDiscardRectangles</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX" returnedonly="true" structextends="VkPhysicalDeviceProperties2KHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>perViewPositionAllComponents</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceSurfaceInfo2KHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>* <name>pNext</name></member>
+            <member><type>VkSurfaceKHR</type> <name>surface</name></member>
+        </type>
+        <type category="struct" name="VkSurfaceCapabilities2KHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*   <name>pNext</name></member>
+            <member><type>VkSurfaceCapabilitiesKHR</type> <name>surfaceCapabilities</name></member>
+        </type>
+        <type category="struct" name="VkSurfaceFormat2KHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>* <name>pNext</name></member>
+            <member><type>VkSurfaceFormatKHR</type> <name>surfaceFormat</name></member>
+        </type>
+        <type category="struct" name="VkSharedPresentSurfaceCapabilitiesKHR" returnedonly="true" structextends="VkSurfaceCapabilities2KHR">
+            <member values="VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true"><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>VkImageUsageFlags</type> <name>sharedPresentSupportedUsageFlags</name><comment>Supported image usage flags if swapchain created using a shared present mode</comment></member>
+        </type>
+        <type category="struct" name="VkPhysicalDevice16BitStorageFeaturesKHR" structextends="VkPhysicalDeviceFeatures2KHR,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true"><type>void</type>*      <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>storageBuffer16BitAccess</name><comment>16-bit integer/floating-point variables supported in BufferBlock</comment></member>
+            <member><type>VkBool32</type>                         <name>uniformAndStorageBuffer16BitAccess</name><comment>16-bit integer/floating-point variables supported in BufferBlock and Block</comment></member>
+            <member><type>VkBool32</type>                         <name>storagePushConstant16</name><comment>16-bit integer/floating-point variables supported in PushConstant</comment></member>
+            <member><type>VkBool32</type>                         <name>storageInputOutput16</name><comment>16-bit integer/floating-point variables supported in shader inputs and outputs</comment></member>
+        </type>
+        <type category="struct" name="VkBufferMemoryRequirementsInfo2KHR">
+            <member values="VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                                                          <name>pNext</name></member>
+            <member><type>VkBuffer</type>                                                             <name>buffer</name></member>
+        </type>
+        <type category="struct" name="VkImageMemoryRequirementsInfo2KHR">
+            <member values="VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                                                          <name>pNext</name></member>
+            <member><type>VkImage</type>                                                              <name>image</name></member>
+        </type>
+        <type category="struct" name="VkImageSparseMemoryRequirementsInfo2KHR">
+            <member values="VK_STRUCTURE_TYPE_IMAGE_SPARSE_MEMORY_REQUIREMENTS_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                                                          <name>pNext</name></member>
+            <member><type>VkImage</type>                                                              <name>image</name></member>
+        </type>
+        <type category="struct" name="VkMemoryRequirements2KHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>* <name>pNext</name></member>
+            <member><type>VkMemoryRequirements</type>                                                 <name>memoryRequirements</name></member>
+        </type>
+        <type category="struct" name="VkSparseImageMemoryRequirements2KHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                                       <name>pNext</name></member>
+            <member><type>VkSparseImageMemoryRequirements</type>                                      <name>memoryRequirements</name></member>
+        </type>
+        <type category="struct" name="VkMemoryDedicatedRequirementsKHR" returnedonly="true" structextends="VkMemoryRequirements2KHR">
+            <member values="VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>prefersDedicatedAllocation</name></member>
+            <member><type>VkBool32</type>                         <name>requiresDedicatedAllocation</name></member>
+        </type>
+        <type category="struct" name="VkMemoryDedicatedAllocateInfoKHR" structextends="VkMemoryAllocateInfo">
+            <member values="VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkImage</type>          <name>image</name><comment>Image that this allocation will be bound to</comment></member>
+            <member optional="true"><type>VkBuffer</type>         <name>buffer</name><comment>Buffer that this allocation will be bound to</comment></member>
+        </type>
+        <type category="struct" name="VkTextureLODGatherFormatPropertiesAMD" returnedonly="true" structextends="VkImageFormatProperties2KHR">
+            <member values="VK_STRUCTURE_TYPE_TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>supportsTextureGatherLODBiasAMD</name></member>
+        </type>
+        <type category="struct" name="VkPipelineCoverageToColorStateCreateInfoNV" structextends="VkPipelineMultisampleStateCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_TO_COLOR_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                                                                      <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineCoverageToColorStateCreateFlagsNV</type>                    <name>flags</name></member>
+            <member><type>VkBool32</type>                         <name>coverageToColorEnable</name></member>
+            <member optional="true"><type>uint32_t</type>         <name>coverageToColorLocation</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2KHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                  <name>pNext</name></member>
+            <member><type>VkBool32</type>               <name>filterMinmaxSingleComponentFormats</name></member>
+            <member><type>VkBool32</type>               <name>filterMinmaxImageComponentMapping</name></member>
+        </type>
+        <type category="struct" name="VkSamplerReductionModeCreateInfoEXT" structextends="VkSamplerCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkSamplerReductionModeEXT</type> <name>reductionMode</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT" structextends="VkPhysicalDeviceFeatures2KHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true"><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>advancedBlendCoherentOperations</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2KHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true"><type>void</type>*                            <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>advancedBlendMaxColorAttachments</name></member>
+            <member><type>VkBool32</type>                         <name>advancedBlendIndependentBlend</name></member>
+            <member><type>VkBool32</type>                         <name>advancedBlendNonPremultipliedSrcColor</name></member>
+            <member><type>VkBool32</type>                         <name>advancedBlendNonPremultipliedDstColor</name></member>
+            <member><type>VkBool32</type>                         <name>advancedBlendCorrelatedOverlap</name></member>
+            <member><type>VkBool32</type>                         <name>advancedBlendAllOperations</name></member>
+        </type>
+        <type category="struct" name="VkPipelineColorBlendAdvancedStateCreateInfoEXT" structextends="VkPipelineColorBlendStateCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkBool32</type>               <name>srcPremultiplied</name></member>
+            <member><type>VkBool32</type>               <name>dstPremultiplied</name></member>
+            <member><type>VkBlendOverlapEXT</type>      <name>blendOverlap</name></member>
+        </type>
+        <type category="struct" name="VkPipelineCoverageModulationStateCreateInfoNV" structextends="VkPipelineMultisampleStateCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                                                                      <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineCoverageModulationStateCreateFlagsNV</type>                   <name>flags</name></member>
+            <member><type>VkCoverageModulationModeNV</type>                                                       <name>coverageModulationMode</name></member>
+            <member><type>VkBool32</type>                                                                         <name>coverageModulationTableEnable</name></member>
+            <member><type>uint32_t</type>                                                                         <name>coverageModulationTableCount</name></member>
+            <member noautovalidity="true" optional="true" len="coverageModulationTableCount">const <type>float</type>* <name>pCoverageModulationTable</name></member>
+        </type>
     </types>
 
-    <!-- SECTION: Vulkan enumerant (token) definitions. -->
+    <comment>Vulkan enumerant (token) definitions</comment>
 
-    <enums name="API Constants" comment="Misc. hardcoded constants - not an enumerated type">
-            <!-- This is part of the header boilerplate -->
+    <enums name="API Constants" comment="Vulkan hardcoded constants - not an enumerated type, part of the header boilerplate">
         <enum value="256"   name="VK_MAX_PHYSICAL_DEVICE_NAME_SIZE"/>
         <enum value="16"    name="VK_UUID_SIZE"/>
+        <enum value="8"     name="VK_LUID_SIZE_KHR"/>
         <enum value="256"   name="VK_MAX_EXTENSION_NAME_SIZE"/>
         <enum value="256"   name="VK_MAX_DESCRIPTION_SIZE"/>
         <enum value="32"    name="VK_MAX_MEMORY_TYPES"/>
-        <enum value="16"    name="VK_MAX_MEMORY_HEAPS"/> <!-- The maximum number of unique memory heaps, each of which supporting 1 or more memory types. -->
+        <enum value="16"    name="VK_MAX_MEMORY_HEAPS" comment="The maximum number of unique memory heaps, each of which supporting 1 or more memory types"/>
         <enum value="1000.0f" name="VK_LOD_CLAMP_NONE"/>
         <enum value="(~0U)" name="VK_REMAINING_MIP_LEVELS"/>
         <enum value="(~0U)" name="VK_REMAINING_ARRAY_LAYERS"/>
@@ -1740,15 +2492,19 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <enum value="1"     name="VK_TRUE"/>
         <enum value="0"     name="VK_FALSE"/>
         <enum value="(~0U)" name="VK_QUEUE_FAMILY_IGNORED"/>
+        <enum value="(~0U-1)" name="VK_QUEUE_FAMILY_EXTERNAL_KHR"/>
         <enum value="(~0U)" name="VK_SUBPASS_EXTERNAL"/>
+        <enum value="32"    name="VK_MAX_DEVICE_GROUP_SIZE_KHX"/>
     </enums>
 
-    <!-- Unlike OpenGL, most tokens in Vulkan are actual typed enumerants in
-         their own numeric namespaces. The "name" attribute is the C enum
-         type name, and is pulled in from a <type> definition above
-         (slightly clunky, but retains the type / enum distinction). "type"
-         attributes of "enum" or "bitmask" indicate that these values should
-         be generated inside an appropriate definition. -->
+    <comment>
+        Unlike OpenGL, most tokens in Vulkan are actual typed enumerants in
+        their own numeric namespaces. The "name" attribute is the C enum
+        type name, and is pulled in from a type tag definition above
+        (slightly clunky, but retains the type / enum distinction). "type"
+        attributes of "enum" or "bitmask" indicate that these values should
+        be generated inside an appropriate definition.
+    </comment>
 
     <enums name="VkImageLayout" type="enum">
         <enum value="0"     name="VK_IMAGE_LAYOUT_UNDEFINED"                         comment="Implicit layout an image is when its contents are undefined due to various reasons (e.g. right after creation)"/>
@@ -1868,7 +2624,11 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <enum value="1"     name="VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT"/>
         <enum value="2"     name="VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE"/>
         <enum value="3"     name="VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER"/>
-        <!-- <enum value="4"     name="VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE" comment="Reserved for VK_KHR_sampler_mirror_clamp_to_edge, do not alias!"/> -->
+            <comment>
+                value="4" reserved for VK_KHR_sampler_mirror_clamp_to_edge
+                enum VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE; do not
+                alias!
+            </comment>
     </enums>
     <enums name="VkCompareOp" type="enum">
         <enum value="0"     name="VK_COMPARE_OP_NEVER"/>
@@ -2207,22 +2967,22 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <enum value="44"    name="VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER"/>
         <enum value="45"    name="VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER"/>
         <enum value="46"    name="VK_STRUCTURE_TYPE_MEMORY_BARRIER"/>
-        <enum value="47"    name="VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO"/> <!-- Reserved for internal use by the loader, layers, and ICDs -->
-        <enum value="48"    name="VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO"/> <!-- Reserved for internal use by the loader, layers, and ICDs -->
+        <enum value="47"    name="VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO" comment="Reserved for internal use by the loader, layers, and ICDs"/>
+        <enum value="48"    name="VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO" comment="Reserved for internal use by the loader, layers, and ICDs"/>
     </enums>
     <enums name="VkSubpassContents" type="enum">
         <enum value="0"     name="VK_SUBPASS_CONTENTS_INLINE"/>
         <enum value="1"     name="VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS"/>
     </enums>
-    <enums name="VkResult" type="enum" comment="Error and return codes">
-        <!-- Return codes for successful operation execution (positive values) -->
+    <enums name="VkResult" type="enum" comment="API result codes">
+            <comment>Return codes (positive values)</comment>
         <enum value="0"     name="VK_SUCCESS" comment="Command completed successfully"/>
         <enum value="1"     name="VK_NOT_READY" comment="A fence or query has not yet completed"/>
         <enum value="2"     name="VK_TIMEOUT" comment="A wait operation has not completed in the specified time"/>
         <enum value="3"     name="VK_EVENT_SET" comment="An event is signaled"/>
         <enum value="4"     name="VK_EVENT_RESET" comment="An event is unsignaled"/>
         <enum value="5"     name="VK_INCOMPLETE" comment="A return array was too small for the result"/>
-        <!-- Error codes (negative values) -->
+            <comment>Error codes (negative values)</comment>
         <enum value="-1"    name="VK_ERROR_OUT_OF_HOST_MEMORY" comment="A host memory allocation has failed"/>
         <enum value="-2"    name="VK_ERROR_OUT_OF_DEVICE_MEMORY" comment="A device memory allocation has failed"/>
         <enum value="-3"    name="VK_ERROR_INITIALIZATION_FAILED" comment="Initialization of a object has failed"/>
@@ -2248,8 +3008,40 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <enum value="7"    name="VK_DYNAMIC_STATE_STENCIL_WRITE_MASK"/>
         <enum value="8"    name="VK_DYNAMIC_STATE_STENCIL_REFERENCE"/>
     </enums>
+    <enums name="VkDescriptorUpdateTemplateTypeKHR" type="enum">
+        <enum value="0"    name="VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET_KHR"   comment="Create descriptor update template for descriptor set updates"/>
+        <enum value="1"    name="VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR" comment="Create descriptor update template for pushed descriptor updates"/>
+    </enums>
+    <enums name="VkObjectType" type="enum" comment="Enums to track objects of various types">
+        <enum value="0" name="VK_OBJECT_TYPE_UNKNOWN"/>
+        <enum value="1" name="VK_OBJECT_TYPE_INSTANCE"                               comment="VkInstance"/>
+        <enum value="2" name="VK_OBJECT_TYPE_PHYSICAL_DEVICE"                        comment="VkPhysicalDevice"/>
+        <enum value="3" name="VK_OBJECT_TYPE_DEVICE"                                 comment="VkDevice"/>
+        <enum value="4" name="VK_OBJECT_TYPE_QUEUE"                                  comment="VkQueue"/>
+        <enum value="5" name="VK_OBJECT_TYPE_SEMAPHORE"                              comment="VkSemaphore"/>
+        <enum value="6" name="VK_OBJECT_TYPE_COMMAND_BUFFER"                         comment="VkCommandBuffer"/>
+        <enum value="7" name="VK_OBJECT_TYPE_FENCE"                                  comment="VkFence"/>
+        <enum value="8" name="VK_OBJECT_TYPE_DEVICE_MEMORY"                          comment="VkDeviceMemory"/>
+        <enum value="9" name="VK_OBJECT_TYPE_BUFFER"                                 comment="VkBuffer"/>
+        <enum value="10" name="VK_OBJECT_TYPE_IMAGE"                                 comment="VkImage"/>
+        <enum value="11" name="VK_OBJECT_TYPE_EVENT"                                 comment="VkEvent"/>
+        <enum value="12" name="VK_OBJECT_TYPE_QUERY_POOL"                            comment="VkQueryPool"/>
+        <enum value="13" name="VK_OBJECT_TYPE_BUFFER_VIEW"                           comment="VkBufferView"/>
+        <enum value="14" name="VK_OBJECT_TYPE_IMAGE_VIEW"                            comment="VkImageView"/>
+        <enum value="15" name="VK_OBJECT_TYPE_SHADER_MODULE"                         comment="VkShaderModule"/>
+        <enum value="16" name="VK_OBJECT_TYPE_PIPELINE_CACHE"                        comment="VkPipelineCache"/>
+        <enum value="17" name="VK_OBJECT_TYPE_PIPELINE_LAYOUT"                       comment="VkPipelineLayout"/>
+        <enum value="18" name="VK_OBJECT_TYPE_RENDER_PASS"                           comment="VkRenderPass"/>
+        <enum value="19" name="VK_OBJECT_TYPE_PIPELINE"                              comment="VkPipeline"/>
+        <enum value="20" name="VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT"                 comment="VkDescriptorSetLayout"/>
+        <enum value="21" name="VK_OBJECT_TYPE_SAMPLER"                               comment="VkSampler"/>
+        <enum value="22" name="VK_OBJECT_TYPE_DESCRIPTOR_POOL"                       comment="VkDescriptorPool"/>
+        <enum value="23" name="VK_OBJECT_TYPE_DESCRIPTOR_SET"                        comment="VkDescriptorSet"/>
+        <enum value="24" name="VK_OBJECT_TYPE_FRAMEBUFFER"                           comment="VkFramebuffer"/>
+        <enum value="25" name="VK_OBJECT_TYPE_COMMAND_POOL"                          comment="VkCommandPool"/>
+    </enums>
 
-    <!-- Flags -->
+        <comment>Flags</comment>
     <enums name="VkQueueFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_QUEUE_GRAPHICS_BIT"                             comment="Queue supports graphics operations"/>
         <enum bitpos="1"    name="VK_QUEUE_COMPUTE_BIT"                              comment="Queue supports compute operations"/>
@@ -2450,7 +3242,8 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
     <enums name="VkDependencyFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_DEPENDENCY_BY_REGION_BIT"                       comment="Dependency is per pixel region "/>
     </enums>
-        <!-- WSI extensions -->
+
+        <comment>WSI Extensions</comment>
     <enums name="VkPresentModeKHR" type="enum">
         <enum value="0"     name="VK_PRESENT_MODE_IMMEDIATE_KHR"/>
         <enum value="1"     name="VK_PRESENT_MODE_MAILBOX_KHR"/>
@@ -2519,19 +3312,15 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <enum value="25" name="VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT"/>
         <enum value="26" name="VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT"/>
         <enum value="27" name="VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT"/>
-        <enum value="28" name="VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT"/>
+        <enum value="28" name="VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT"/>
         <enum value="29" name="VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT"/>
         <enum value="30" name="VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT"/>
         <enum value="31" name="VK_DEBUG_REPORT_OBJECT_TYPE_OBJECT_TABLE_NVX_EXT"/>
         <enum value="32" name="VK_DEBUG_REPORT_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NVX_EXT"/>
     </enums>
-    <enums name="VkDebugReportErrorEXT" type="enum">
-        <enum value="0" name="VK_DEBUG_REPORT_ERROR_NONE_EXT"/>         <!-- Used for INFO & other non-error messages -->
-        <enum value="1" name="VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT"/> <!-- Callbacks were not destroyed prior to calling DestroyInstance -->
-    </enums>
     <enums name="VkRasterizationOrderAMD" type="enum">
-        <enum value="0" name="VK_RASTERIZATION_ORDER_STRICT_AMD"/>      <!-- Rasterization order strictly follows API order -->
-        <enum value="1" name="VK_RASTERIZATION_ORDER_RELAXED_AMD"/>     <!-- Rasterization order may not follow API order -->
+        <enum value="0" name="VK_RASTERIZATION_ORDER_STRICT_AMD"/>
+        <enum value="1" name="VK_RASTERIZATION_ORDER_RELAXED_AMD"/>
     </enums>
     <enums name="VkExternalMemoryHandleTypeFlagBitsNV" type="bitmask">
         <enum bitpos="0" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_NV"/>
@@ -2546,37 +3335,144 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
     </enums>
     <enums name="VkValidationCheckEXT" type="enum">
         <enum value="0" name="VK_VALIDATION_CHECK_ALL_EXT"/>
-        <!-- Placeholder for validation enums to be defined for VK_EXT_Validation_flags extension -->
+        <enum value="1" name="VK_VALIDATION_CHECK_SHADERS_EXT"/>
+            <comment>Placeholder for validation enums to be defined for VK_EXT_Validation_flags extension</comment>
     </enums>
     <enums name="VkIndirectCommandsLayoutUsageFlagBitsNVX" type="bitmask">
-        <enum bitpos="0" name="VK_INDIRECT_COMMANDS_LAYOUT_USAGE_UNORDERED_SEQUENCES_BIT_NVX"/> <!-- sequences can be processed in implementation-dependent order -->
-        <enum bitpos="1" name="VK_INDIRECT_COMMANDS_LAYOUT_USAGE_SPARSE_SEQUENCES_BIT_NVX"/>    <!-- likely generated with a high difference in actual sequencesCount and maxSequencesCount -->
-        <enum bitpos="2" name="VK_INDIRECT_COMMANDS_LAYOUT_USAGE_EMPTY_EXECUTIONS_BIT_NVX"/>    <!-- likely to contain draw/dispatch calls that are zero-sized -->
-        <enum bitpos="3" name="VK_INDIRECT_COMMANDS_LAYOUT_USAGE_INDEXED_SEQUENCES_BIT_NVX"/>   <!-- custom sequence index permutation (32-bit) is provided -->
+        <enum bitpos="0" name="VK_INDIRECT_COMMANDS_LAYOUT_USAGE_UNORDERED_SEQUENCES_BIT_NVX"/>
+        <enum bitpos="1" name="VK_INDIRECT_COMMANDS_LAYOUT_USAGE_SPARSE_SEQUENCES_BIT_NVX"/>
+        <enum bitpos="2" name="VK_INDIRECT_COMMANDS_LAYOUT_USAGE_EMPTY_EXECUTIONS_BIT_NVX"/>
+        <enum bitpos="3" name="VK_INDIRECT_COMMANDS_LAYOUT_USAGE_INDEXED_SEQUENCES_BIT_NVX"/>
     </enums>
     <enums name="VkObjectEntryUsageFlagBitsNVX" type="bitmask">
         <enum bitpos="0" name="VK_OBJECT_ENTRY_USAGE_GRAPHICS_BIT_NVX"/>
         <enum bitpos="1" name="VK_OBJECT_ENTRY_USAGE_COMPUTE_BIT_NVX"/>
     </enums>
     <enums name="VkIndirectCommandsTokenTypeNVX" type="enum">
-        <enum value="0" name="VK_INDIRECT_COMMANDS_TOKEN_PIPELINE_NVX"/>        <!-- array of 32bit tableEntry in the object table -->
-        <enum value="1" name="VK_INDIRECT_COMMANDS_TOKEN_DESCRIPTOR_SET_NVX"/>  <!-- array of (32 bit tableEntry + variable count 32bit offsets) -->
-        <enum value="2" name="VK_INDIRECT_COMMANDS_TOKEN_INDEX_BUFFER_NVX"/>    <!-- array of (32 bit tableEntry + optional 32bit offset) -->
-        <enum value="3" name="VK_INDIRECT_COMMANDS_TOKEN_VERTEX_BUFFER_NVX"/>   <!-- array of (32 bit tableEntry + optional 32bit offset) -->
-        <enum value="4" name="VK_INDIRECT_COMMANDS_TOKEN_PUSH_CONSTANT_NVX"/>   <!-- array of (32 bit tableEntry + variable count 32bit values ) -->
-        <enum value="5" name="VK_INDIRECT_COMMANDS_TOKEN_DRAW_INDEXED_NVX"/>    <!-- array of VkDrawIndexedIndirectCommand -->
-        <enum value="6" name="VK_INDIRECT_COMMANDS_TOKEN_DRAW_NVX"/>            <!-- array of VkDrawIndirectCommand -->
-        <enum value="7" name="VK_INDIRECT_COMMANDS_TOKEN_DISPATCH_NVX"/>        <!-- array of VkDispatchIndirectCommand -->
+        <enum value="0" name="VK_INDIRECT_COMMANDS_TOKEN_TYPE_PIPELINE_NVX"/>
+        <enum value="1" name="VK_INDIRECT_COMMANDS_TOKEN_TYPE_DESCRIPTOR_SET_NVX"/>
+        <enum value="2" name="VK_INDIRECT_COMMANDS_TOKEN_TYPE_INDEX_BUFFER_NVX"/>
+        <enum value="3" name="VK_INDIRECT_COMMANDS_TOKEN_TYPE_VERTEX_BUFFER_NVX"/>
+        <enum value="4" name="VK_INDIRECT_COMMANDS_TOKEN_TYPE_PUSH_CONSTANT_NVX"/>
+        <enum value="5" name="VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_INDEXED_NVX"/>
+        <enum value="6" name="VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_NVX"/>
+        <enum value="7" name="VK_INDIRECT_COMMANDS_TOKEN_TYPE_DISPATCH_NVX"/>
     </enums>
     <enums name="VkObjectEntryTypeNVX" type="enum">
-        <enum value="0" name="VK_OBJECT_ENTRY_DESCRIPTOR_SET_NVX"/>
-        <enum value="1" name="VK_OBJECT_ENTRY_PIPELINE_NVX"/>
-        <enum value="2" name="VK_OBJECT_ENTRY_INDEX_BUFFER_NVX"/>
-        <enum value="3" name="VK_OBJECT_ENTRY_VERTEX_BUFFER_NVX"/>
-        <enum value="4" name="VK_OBJECT_ENTRY_PUSH_CONSTANT_NVX"/>
+        <enum value="0" name="VK_OBJECT_ENTRY_TYPE_DESCRIPTOR_SET_NVX"/>
+        <enum value="1" name="VK_OBJECT_ENTRY_TYPE_PIPELINE_NVX"/>
+        <enum value="2" name="VK_OBJECT_ENTRY_TYPE_INDEX_BUFFER_NVX"/>
+        <enum value="3" name="VK_OBJECT_ENTRY_TYPE_VERTEX_BUFFER_NVX"/>
+        <enum value="4" name="VK_OBJECT_ENTRY_TYPE_PUSH_CONSTANT_NVX"/>
     </enums>
-    <!-- SECTION: Vulkan command definitions -->
-    <commands>
+    <enums name="VkDescriptorSetLayoutCreateFlagBits" type="bitmask">
+    </enums>
+    <enums name="VkExternalMemoryHandleTypeFlagBitsKHR" type="bitmask">
+        <enum bitpos="0" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR"/>
+        <enum bitpos="1" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR"/>
+        <enum bitpos="2" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_KHR"/>
+        <enum bitpos="3" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT_KHR"/>
+        <enum bitpos="4" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT_BIT_KHR"/>
+        <enum bitpos="5" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP_BIT_KHR"/>
+        <enum bitpos="6" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE_BIT_KHR"/>
+    </enums>
+    <enums name="VkExternalMemoryFeatureFlagBitsKHR" type="bitmask">
+        <enum bitpos="0" name="VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT_KHR"/>
+        <enum bitpos="1" name="VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT_KHR"/>
+        <enum bitpos="2" name="VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT_KHR"/>
+    </enums>
+    <enums name="VkExternalSemaphoreHandleTypeFlagBitsKHR" type="bitmask">
+        <enum bitpos="0" name="VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT_KHR"/>
+        <enum bitpos="1" name="VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR"/>
+        <enum bitpos="2" name="VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_KHR"/>
+        <enum bitpos="3" name="VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT_KHR"/>
+        <enum bitpos="4" name="VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT_KHR"/>
+    </enums>
+    <enums name="VkExternalSemaphoreFeatureFlagBitsKHR" type="bitmask">
+        <enum bitpos="0" name="VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR"/>
+        <enum bitpos="1" name="VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT_KHR"/>
+    </enums>
+    <enums name="VkSemaphoreImportFlagBitsKHR" type="bitmask">
+        <enum bitpos="0" name="VK_SEMAPHORE_IMPORT_TEMPORARY_BIT_KHR"/>
+    </enums>
+    <enums name="VkExternalFenceHandleTypeFlagBitsKHR" type="bitmask">
+        <enum bitpos="0" name="VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT_KHR"/>
+        <enum bitpos="1" name="VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR"/>
+        <enum bitpos="2" name="VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_KHR"/>
+        <enum bitpos="3" name="VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT_KHR"/>
+    </enums>
+    <enums name="VkExternalFenceFeatureFlagBitsKHR" type="bitmask">
+        <enum bitpos="0" name="VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR"/>
+        <enum bitpos="1" name="VK_EXTERNAL_FENCE_FEATURE_IMPORTABLE_BIT_KHR"/>
+    </enums>
+    <enums name="VkFenceImportFlagBitsKHR" type="bitmask">
+        <enum bitpos="0" name="VK_FENCE_IMPORT_TEMPORARY_BIT_KHR"/>
+    </enums>
+    <enums name="VkSurfaceCounterFlagBitsEXT" type="bitmask">
+        <enum bitpos="0" name="VK_SURFACE_COUNTER_VBLANK_EXT"/>
+    </enums>
+    <enums name="VkDisplayPowerStateEXT" type="enum">
+        <enum value="0" name="VK_DISPLAY_POWER_STATE_OFF_EXT"/>
+        <enum value="1" name="VK_DISPLAY_POWER_STATE_SUSPEND_EXT"/>
+        <enum value="2" name="VK_DISPLAY_POWER_STATE_ON_EXT"/>
+    </enums>
+    <enums name="VkDeviceEventTypeEXT" type="enum">
+        <enum value="0" name="VK_DEVICE_EVENT_TYPE_DISPLAY_HOTPLUG_EXT"/>
+    </enums>
+    <enums name="VkDisplayEventTypeEXT" type="enum">
+        <enum value="0" name="VK_DISPLAY_EVENT_TYPE_FIRST_PIXEL_OUT_EXT"/>
+    </enums>
+    <enums name="VkPeerMemoryFeatureFlagBitsKHX" type="bitmask">
+        <enum bitpos="0"    name="VK_PEER_MEMORY_FEATURE_COPY_SRC_BIT_KHX"           comment="Can read with vkCmdCopy commands"/>
+        <enum bitpos="1"    name="VK_PEER_MEMORY_FEATURE_COPY_DST_BIT_KHX"           comment="Can write with vkCmdCopy commands"/>
+        <enum bitpos="2"    name="VK_PEER_MEMORY_FEATURE_GENERIC_SRC_BIT_KHX"        comment="Can read with any access type/command"/>
+        <enum bitpos="3"    name="VK_PEER_MEMORY_FEATURE_GENERIC_DST_BIT_KHX"        comment="Can write with and access type/command"/>
+    </enums>
+    <enums name="VkMemoryAllocateFlagBitsKHX" type="bitmask">
+        <enum bitpos="0"    name="VK_MEMORY_ALLOCATE_DEVICE_MASK_BIT_KHX"            comment="Force allocation on specific devices"/>
+    </enums>
+    <enums name="VkDeviceGroupPresentModeFlagBitsKHX" type="bitmask">
+        <enum bitpos="0"    name="VK_DEVICE_GROUP_PRESENT_MODE_LOCAL_BIT_KHX"        comment="Present from local memory"/>
+        <enum bitpos="1"    name="VK_DEVICE_GROUP_PRESENT_MODE_REMOTE_BIT_KHX"       comment="Present from remote memory"/>
+        <enum bitpos="2"    name="VK_DEVICE_GROUP_PRESENT_MODE_SUM_BIT_KHX"          comment="Present sum of local and/or remote memory"/>
+        <enum bitpos="3"    name="VK_DEVICE_GROUP_PRESENT_MODE_LOCAL_MULTI_DEVICE_BIT_KHX" comment="Each physical device presents from local memory"/>
+    </enums>
+    <enums name="VkSwapchainCreateFlagBitsKHR" type="bitmask">
+    </enums>
+    <enums name="VkViewportCoordinateSwizzleNV" type="enum">
+        <enum value="0" name="VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_X_NV"/>
+        <enum value="1" name="VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_X_NV"/>
+        <enum value="2" name="VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_Y_NV"/>
+        <enum value="3" name="VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_Y_NV"/>
+        <enum value="4" name="VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_Z_NV"/>
+        <enum value="5" name="VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_Z_NV"/>
+        <enum value="6" name="VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_W_NV"/>
+        <enum value="7" name="VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_W_NV"/>
+    </enums>
+    <enums name="VkDiscardRectangleModeEXT" type="enum">
+        <enum value="0"     name="VK_DISCARD_RECTANGLE_MODE_INCLUSIVE_EXT"/>
+        <enum value="1"     name="VK_DISCARD_RECTANGLE_MODE_EXCLUSIVE_EXT"/>
+    </enums>
+    <enums name="VkSubpassDescriptionFlagBits" type="bitmask">
+    </enums>
+    <enums name="VkSamplerReductionModeEXT" type="enum">
+        <enum value="0"     name="VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE_EXT"/>
+        <enum value="1"     name="VK_SAMPLER_REDUCTION_MODE_MIN_EXT"/>
+        <enum value="2"     name="VK_SAMPLER_REDUCTION_MODE_MAX_EXT"/>
+    </enums>
+    <enums name="VkBlendOverlapEXT" type="enum">
+        <enum value="0"     name="VK_BLEND_OVERLAP_UNCORRELATED_EXT"/>
+        <enum value="1"     name="VK_BLEND_OVERLAP_DISJOINT_EXT"/>
+        <enum value="2"     name="VK_BLEND_OVERLAP_CONJOINT_EXT"/>
+    </enums>
+    <enums name="VkCoverageModulationModeNV" type="enum">
+        <enum value="0"     name="VK_COVERAGE_MODULATION_MODE_NONE_NV"/>
+        <enum value="1"     name="VK_COVERAGE_MODULATION_MODE_RGB_NV"/>
+        <enum value="2"     name="VK_COVERAGE_MODULATION_MODE_ALPHA_NV"/>
+        <enum value="3"     name="VK_COVERAGE_MODULATION_MODE_RGBA_NV"/>
+    </enums>
+
+    <commands comment="Vulkan command definitions">
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_LAYER_NOT_PRESENT,VK_ERROR_EXTENSION_NOT_PRESENT,VK_ERROR_INCOMPATIBLE_DRIVER">
             <proto><type>VkResult</type> <name>vkCreateInstance</name></proto>
             <param>const <type>VkInstanceCreateInfo</type>* <name>pCreateInfo</name></param>
@@ -2702,7 +3598,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <param>all sname:VkQueue objects created from pname:device</param>
             </implicitexternsyncparams>
         </command>
-        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_TOO_MANY_OBJECTS">
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR">
             <proto><type>VkResult</type> <name>vkAllocateMemory</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param>const <type>VkMemoryAllocateInfo</type>* <name>pAllocateInfo</name></param>
@@ -3079,7 +3975,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <param>any sname:VkDescriptorSet objects allocated from pname:descriptorPool</param>
             </implicitexternsyncparams>
         </command>
-        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FRAGMENTED_POOL">
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FRAGMENTED_POOL,VK_ERROR_OUT_OF_POOL_MEMORY_KHR">
             <proto><type>VkResult</type> <name>vkAllocateDescriptorSets</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param externsync="pAllocateInfo::descriptorPool">const <type>VkDescriptorSetAllocateInfo</type>* <name>pAllocateInfo</name></param>
@@ -3307,9 +4203,9 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <command queues="compute" renderpass="outside" cmdbufferlevel="primary,secondary" pipeline="compute">
             <proto><type>void</type> <name>vkCmdDispatch</name></proto>
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
-            <param><type>uint32_t</type> <name>x</name></param>
-            <param><type>uint32_t</type> <name>y</name></param>
-            <param><type>uint32_t</type> <name>z</name></param>
+            <param><type>uint32_t</type> <name>groupCountX</name></param>
+            <param><type>uint32_t</type> <name>groupCountY</name></param>
+            <param><type>uint32_t</type> <name>groupCountZ</name></param>
         </command>
         <command queues="compute" renderpass="outside" cmdbufferlevel="primary,secondary" pipeline="compute">
             <proto><type>void</type> <name>vkCmdDispatchIndirect</name></proto>
@@ -3372,7 +4268,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <param><type>VkDeviceSize</type> <name>dataSize</name></param>
             <param len="dataSize">const <type>void</type>* <name>pData</name></param>
         </command>
-        <command queues="graphics,compute" renderpass="outside" cmdbufferlevel="primary,secondary" pipeline="transfer">
+        <command queues="transfer,graphics,compute" renderpass="outside" cmdbufferlevel="primary,secondary" pipeline="transfer" comment="transfer support is only available when VK_KHR_maintenance1 is enabled, as documented in valid usage language in the specification">
             <proto><type>void</type> <name>vkCmdFillBuffer</name></proto>
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param><type>VkBuffer</type> <name>dstBuffer</name></param>
@@ -3666,6 +4562,13 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <param externsync="true"><type>VkQueue</type> <name>queue</name></param>
             <param externsync="pPresentInfo.pWaitSemaphores[],pPresentInfo.pSwapchains[]">const <type>VkPresentInfoKHR</type>* <name>pPresentInfo</name></param>
         </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR">
+            <proto><type>VkResult</type> <name>vkCreateViSurfaceNN</name></proto>
+            <param><type>VkInstance</type> <name>instance</name></param>
+            <param>const <type>VkViSurfaceCreateInfoNN</type>* <name>pCreateInfo</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param><type>VkSurfaceKHR</type>* <name>pSurface</name></param>
+        </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkCreateWaylandSurfaceKHR</name></proto>
             <param><type>VkInstance</type> <name>instance</name></param>
@@ -3746,17 +4649,17 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkDebugMarkerSetObjectNameEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="pNameInfo.object"><type>VkDebugMarkerObjectNameInfoEXT</type>* <name>pNameInfo</name></param>
+            <param externsync="pNameInfo.object">const <type>VkDebugMarkerObjectNameInfoEXT</type>* <name>pNameInfo</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkDebugMarkerSetObjectTagEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="pTagInfo.object"><type>VkDebugMarkerObjectTagInfoEXT</type>* <name>pTagInfo</name></param>
+            <param externsync="pTagInfo.object">const <type>VkDebugMarkerObjectTagInfoEXT</type>* <name>pTagInfo</name></param>
         </command>
         <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary">
             <proto><type>void</type> <name>vkCmdDebugMarkerBeginEXT</name></proto>
             <param><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
-            <param><type>VkDebugMarkerMarkerInfoEXT</type>* <name>pMarkerInfo</name></param>
+            <param>const <type>VkDebugMarkerMarkerInfoEXT</type>* <name>pMarkerInfo</name></param>
         </command>
         <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary">
             <proto><type>void</type> <name>vkCmdDebugMarkerEndEXT</name></proto>
@@ -3765,7 +4668,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary">
             <proto><type>void</type> <name>vkCmdDebugMarkerInsertEXT</name></proto>
             <param><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
-            <param><type>VkDebugMarkerMarkerInfoEXT</type>* <name>pMarkerInfo</name></param>
+            <param>const <type>VkDebugMarkerMarkerInfoEXT</type>* <name>pMarkerInfo</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FORMAT_NOT_SUPPORTED">
             <proto><type>VkResult</type> <name>vkGetPhysicalDeviceExternalImageFormatPropertiesNV</name></proto>
@@ -3863,10 +4766,382 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <param><type>VkDeviceGeneratedCommandsFeaturesNVX</type>* <name>pFeatures</name></param>
             <param><type>VkDeviceGeneratedCommandsLimitsNVX</type>* <name>pLimits</name></param>
         </command>
+        <command>
+            <proto><type>void</type> <name>vkGetPhysicalDeviceFeatures2KHR</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param><type>VkPhysicalDeviceFeatures2KHR</type>* <name>pFeatures</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkGetPhysicalDeviceProperties2KHR</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param><type>VkPhysicalDeviceProperties2KHR</type>* <name>pProperties</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkGetPhysicalDeviceFormatProperties2KHR</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param><type>VkFormat</type> <name>format</name></param>
+            <param><type>VkFormatProperties2KHR</type>* <name>pFormatProperties</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FORMAT_NOT_SUPPORTED">
+            <proto><type>VkResult</type> <name>vkGetPhysicalDeviceImageFormatProperties2KHR</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param>const <type>VkPhysicalDeviceImageFormatInfo2KHR</type>* <name>pImageFormatInfo</name></param>
+            <param><type>VkImageFormatProperties2KHR</type>* <name>pImageFormatProperties</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkGetPhysicalDeviceQueueFamilyProperties2KHR</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param optional="false,true"><type>uint32_t</type>* <name>pQueueFamilyPropertyCount</name></param>
+            <param optional="true" len="pQueueFamilyPropertyCount"><type>VkQueueFamilyProperties2KHR</type>* <name>pQueueFamilyProperties</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkGetPhysicalDeviceMemoryProperties2KHR</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param><type>VkPhysicalDeviceMemoryProperties2KHR</type>* <name>pMemoryProperties</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkGetPhysicalDeviceSparseImageFormatProperties2KHR</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param>const <type>VkPhysicalDeviceSparseImageFormatInfo2KHR</type>* <name>pFormatInfo</name></param>
+            <param optional="false,true"><type>uint32_t</type>* <name>pPropertyCount</name></param>
+            <param optional="true" len="pPropertyCount"><type>VkSparseImageFormatProperties2KHR</type>* <name>pProperties</name></param>
+        </command>
+        <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary">
+            <proto><type>void</type> <name>vkCmdPushDescriptorSetKHR</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param><type>VkPipelineBindPoint</type> <name>pipelineBindPoint</name></param>
+            <param><type>VkPipelineLayout</type> <name>layout</name></param>
+            <param><type>uint32_t</type> <name>set</name></param>
+            <param><type>uint32_t</type> <name>descriptorWriteCount</name></param>
+            <param len="descriptorWriteCount">const <type>VkWriteDescriptorSet</type>* <name>pDescriptorWrites</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkTrimCommandPoolKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param externsync="true"><type>VkCommandPool</type> <name>commandPool</name></param>
+            <param optional="true"><type>VkCommandPoolTrimFlagsKHR</type> <name>flags</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkGetPhysicalDeviceExternalBufferPropertiesKHR</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param>const <type>VkPhysicalDeviceExternalBufferInfoKHR</type>* <name>pExternalBufferInfo</name></param>
+            <param><type>VkExternalBufferPropertiesKHR</type>* <name>pExternalBufferProperties</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetMemoryWin32HandleKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkMemoryGetWin32HandleInfoKHR</type>* <name>pGetWin32HandleInfo</name></param>
+            <param><type>HANDLE</type>* <name>pHandle</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR">
+            <proto><type>VkResult</type> <name>vkGetMemoryWin32HandlePropertiesKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></param>
+            <param><type>HANDLE</type> <name>handle</name></param>
+            <param><type>VkMemoryWin32HandlePropertiesKHR</type>* <name>pMemoryWin32HandleProperties</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetMemoryFdKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkMemoryGetFdInfoKHR</type>* <name>pGetFdInfo</name></param>
+            <param><type>int</type>* <name>pFd</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR">
+            <proto><type>VkResult</type> <name>vkGetMemoryFdPropertiesKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></param>
+            <param><type>int</type> <name>fd</name></param>
+            <param><type>VkMemoryFdPropertiesKHR</type>* <name>pMemoryFdProperties</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkGetPhysicalDeviceExternalSemaphorePropertiesKHR</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param>const <type>VkPhysicalDeviceExternalSemaphoreInfoKHR</type>* <name>pExternalSemaphoreInfo</name></param>
+            <param><type>VkExternalSemaphorePropertiesKHR</type>* <name>pExternalSemaphoreProperties</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetSemaphoreWin32HandleKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkSemaphoreGetWin32HandleInfoKHR</type>* <name>pGetWin32HandleInfo</name></param>
+            <param><type>HANDLE</type>* <name>pHandle</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR">
+            <proto><type>VkResult</type> <name>vkImportSemaphoreWin32HandleKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkImportSemaphoreWin32HandleInfoKHR</type>* <name>pImportSemaphoreWin32HandleInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetSemaphoreFdKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkSemaphoreGetFdInfoKHR</type>* <name>pGetFdInfo</name></param>
+            <param><type>int</type>* <name>pFd</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR">
+            <proto><type>VkResult</type> <name>vkImportSemaphoreFdKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkImportSemaphoreFdInfoKHR</type>* <name>pImportSemaphoreFdInfo</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkGetPhysicalDeviceExternalFencePropertiesKHR</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param>const <type>VkPhysicalDeviceExternalFenceInfoKHR</type>* <name>pExternalFenceInfo</name></param>
+            <param><type>VkExternalFencePropertiesKHR</type>* <name>pExternalFenceProperties</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetFenceWin32HandleKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkFenceGetWin32HandleInfoKHR</type>* <name>pGetWin32HandleInfo</name></param>
+            <param><type>HANDLE</type>* <name>pHandle</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR">
+            <proto><type>VkResult</type> <name>vkImportFenceWin32HandleKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkImportFenceWin32HandleInfoKHR</type>* <name>pImportFenceWin32HandleInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetFenceFdKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkFenceGetFdInfoKHR</type>* <name>pGetFdInfo</name></param>
+            <param><type>int</type>* <name>pFd</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR">
+            <proto><type>VkResult</type> <name>vkImportFenceFdKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkImportFenceFdInfoKHR</type>* <name>pImportFenceFdInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS">
+            <proto><type>VkResult</type> <name>vkReleaseDisplayEXT</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param><type>VkDisplayKHR</type> <name>display</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED">
+            <proto><type>VkResult</type> <name>vkAcquireXlibDisplayEXT</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param><type>Display</type>* <name>dpy</name></param>
+            <param><type>VkDisplayKHR</type> <name>display</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS">
+            <proto><type>VkResult</type> <name>vkGetRandROutputDisplayEXT</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param><type>Display</type>* <name>dpy</name></param>
+            <param><type>RROutput</type> <name>rrOutput</name></param>
+            <param><type>VkDisplayKHR</type>* <name>pDisplay</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS">
+            <proto><type>VkResult</type> <name>vkDisplayPowerControlEXT</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkDisplayKHR</type> <name>display</name></param>
+            <param>const <type>VkDisplayPowerInfoEXT</type>* <name>pDisplayPowerInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS">
+            <proto><type>VkResult</type> <name>vkRegisterDeviceEventEXT</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkDeviceEventInfoEXT</type>* <name>pDeviceEventInfo</name></param>
+            <param>const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param><type>VkFence</type>* <name>pFence</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS">
+            <proto><type>VkResult</type> <name>vkRegisterDisplayEventEXT</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkDisplayKHR</type> <name>display</name></param>
+            <param>const <type>VkDisplayEventInfoEXT</type>* <name>pDisplayEventInfo</name></param>
+            <param>const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param><type>VkFence</type>* <name>pFence</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR">
+            <proto><type>VkResult</type> <name>vkGetSwapchainCounterEXT</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkSwapchainKHR</type> <name>swapchain</name></param>
+            <param><type>VkSurfaceCounterFlagBitsEXT</type> <name>counter</name></param>
+            <param><type>uint64_t</type>* <name>pCounterValue</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR">
+            <proto><type>VkResult</type> <name>vkGetPhysicalDeviceSurfaceCapabilities2EXT</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param><type>VkSurfaceKHR</type> <name>surface</name></param>
+            <param><type>VkSurfaceCapabilities2EXT</type>* <name>pSurfaceCapabilities</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED">
+            <proto><type>VkResult</type> <name>vkEnumeratePhysicalDeviceGroupsKHX</name></proto>
+            <param><type>VkInstance</type> <name>instance</name></param>
+            <param optional="false,true"><type>uint32_t</type>* <name>pPhysicalDeviceGroupCount</name></param>
+            <param optional="true" len="pPhysicalDeviceGroupCount"><type>VkPhysicalDeviceGroupPropertiesKHX</type>* <name>pPhysicalDeviceGroupProperties</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkGetDeviceGroupPeerMemoryFeaturesKHX</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>uint32_t</type> <name>heapIndex</name></param>
+            <param><type>uint32_t</type> <name>localDeviceIndex</name></param>
+            <param><type>uint32_t</type> <name>remoteDeviceIndex</name></param>
+            <param><type>VkPeerMemoryFeatureFlagsKHX</type>* <name>pPeerMemoryFeatures</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkBindBufferMemory2KHX</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>uint32_t</type> <name>bindInfoCount</name></param>
+            <param len="bindInfoCount">const <type>VkBindBufferMemoryInfoKHX</type>* <name>pBindInfos</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkBindImageMemory2KHX</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>uint32_t</type> <name>bindInfoCount</name></param>
+            <param len="bindInfoCount">const <type>VkBindImageMemoryInfoKHX</type>* <name>pBindInfos</name></param>
+        </command>
+        <command queues="graphics,compute,transfer" renderpass="both" cmdbufferlevel="primary,secondary">
+            <proto><type>void</type> <name>vkCmdSetDeviceMaskKHX</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param><type>uint32_t</type> <name>deviceMask</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetDeviceGroupPresentCapabilitiesKHX</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkDeviceGroupPresentCapabilitiesKHX</type>* <name>pDeviceGroupPresentCapabilities</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR">
+            <proto><type>VkResult</type> <name>vkGetDeviceGroupSurfacePresentModesKHX</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param externsync="true"><type>VkSurfaceKHR</type> <name>surface</name></param>
+            <param><type>VkDeviceGroupPresentModeFlagsKHX</type>* <name>pModes</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS,VK_TIMEOUT,VK_NOT_READY,VK_SUBOPTIMAL_KHR" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR">
+            <proto><type>VkResult</type> <name>vkAcquireNextImage2KHX</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkAcquireNextImageInfoKHX</type>* <name>pAcquireInfo</name></param>
+            <param><type>uint32_t</type>* <name>pImageIndex</name></param>
+        </command>
+        <command queues="compute" renderpass="outside" cmdbufferlevel="primary,secondary">
+            <proto><type>void</type> <name>vkCmdDispatchBaseKHX</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param><type>uint32_t</type> <name>baseGroupX</name></param>
+            <param><type>uint32_t</type> <name>baseGroupY</name></param>
+            <param><type>uint32_t</type> <name>baseGroupZ</name></param>
+            <param><type>uint32_t</type> <name>groupCountX</name></param>
+            <param><type>uint32_t</type> <name>groupCountY</name></param>
+            <param><type>uint32_t</type> <name>groupCountZ</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetPhysicalDevicePresentRectanglesKHX</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param externsync="true"><type>VkSurfaceKHR</type> <name>surface</name></param>
+            <param optional="false,true"><type>uint32_t</type>* <name>pRectCount</name></param>
+            <param optional="true" len="pRectCount"><type>VkRect2D</type>* <name>pRects</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkCreateDescriptorUpdateTemplateKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkDescriptorUpdateTemplateCreateInfoKHR</type>* <name>pCreateInfo</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param><type>VkDescriptorUpdateTemplateKHR</type>* <name>pDescriptorUpdateTemplate</name></param>
+         </command>
+        <command>
+            <proto><type>void</type> <name>vkDestroyDescriptorUpdateTemplateKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param optional="true" externsync="true"><type>VkDescriptorUpdateTemplateKHR</type> <name>descriptorUpdateTemplate</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkUpdateDescriptorSetWithTemplateKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param externsync="true"><type>VkDescriptorSet</type> <name>descriptorSet</name></param>
+            <param><type>VkDescriptorUpdateTemplateKHR</type> <name>descriptorUpdateTemplate</name></param>
+            <param>const <type>void</type>* <name>pData</name></param>
+        </command>
+        <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary">
+            <proto><type>void</type> <name>vkCmdPushDescriptorSetWithTemplateKHR</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param><type>VkDescriptorUpdateTemplateKHR</type> <name>descriptorUpdateTemplate</name></param>
+            <param><type>VkPipelineLayout</type> <name>layout</name></param>
+            <param><type>uint32_t</type> <name>set</name></param>
+            <param>const <type>void</type>* <name>pData</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkSetHdrMetadataEXT</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>uint32_t</type> <name>swapchainCount</name></param>
+            <param len="swapchainCount">const <type>VkSwapchainKHR</type>* <name>pSwapchains</name></param>
+            <param len="swapchainCount">const <type>VkHdrMetadataEXT</type>* <name>pMetadata</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS,VK_SUBOPTIMAL_KHR" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR">
+            <proto><type>VkResult</type> <name>vkGetSwapchainStatusKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param externsync="true"><type>VkSwapchainKHR</type> <name>swapchain</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_DEVICE_LOST,VK_ERROR_SURFACE_LOST_KHR">
+            <proto><type>VkResult</type> <name>vkGetRefreshCycleDurationGOOGLE</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param externsync="true"><type>VkSwapchainKHR</type> <name>swapchain</name></param>
+            <param><type>VkRefreshCycleDurationGOOGLE</type>* <name>pDisplayTimingProperties</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR">
+            <proto><type>VkResult</type> <name>vkGetPastPresentationTimingGOOGLE</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param externsync="true"><type>VkSwapchainKHR</type> <name>swapchain</name></param>
+            <param optional="false,true"><type>uint32_t</type>* <name>pPresentationTimingCount</name></param>
+            <param optional="true" len="pPresentationTimingCount"><type>VkPastPresentationTimingGOOGLE</type>* <name>pPresentationTimings</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR">
+            <proto><type>VkResult</type> <name>vkCreateIOSSurfaceMVK</name></proto>
+            <param><type>VkInstance</type> <name>instance</name></param>
+            <param>const <type>VkIOSSurfaceCreateInfoMVK</type>* <name>pCreateInfo</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param><type>VkSurfaceKHR</type>* <name>pSurface</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR">
+            <proto><type>VkResult</type> <name>vkCreateMacOSSurfaceMVK</name></proto>
+            <param><type>VkInstance</type> <name>instance</name></param>
+            <param>const <type>VkMacOSSurfaceCreateInfoMVK</type>* <name>pCreateInfo</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param><type>VkSurfaceKHR</type>* <name>pSurface</name></param>
+        </command>
+        <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary">
+            <proto><type>void</type> <name>vkCmdSetViewportWScalingNV</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param><type>uint32_t</type> <name>firstViewport</name></param>
+            <param><type>uint32_t</type> <name>viewportCount</name></param>
+            <param len="viewportCount" noautovalidity="true">const <type>VkViewportWScalingNV</type>* <name>pViewportWScalings</name></param>
+        </command>
+        <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary">
+            <proto><type>void</type> <name>vkCmdSetDiscardRectangleEXT</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param><type>uint32_t</type> <name>firstDiscardRectangle</name></param>
+            <param><type>uint32_t</type> <name>discardRectangleCount</name></param>
+            <param len="discardRectangleCount">const <type>VkRect2D</type>* <name>pDiscardRectangles</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR">
+            <proto><type>VkResult</type> <name>vkGetPhysicalDeviceSurfaceCapabilities2KHR</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param>const <type>VkPhysicalDeviceSurfaceInfo2KHR</type>* <name>pSurfaceInfo</name></param>
+            <param><type>VkSurfaceCapabilities2KHR</type>* <name>pSurfaceCapabilities</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR">
+            <proto><type>VkResult</type> <name>vkGetPhysicalDeviceSurfaceFormats2KHR</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param>const <type>VkPhysicalDeviceSurfaceInfo2KHR</type>* <name>pSurfaceInfo</name></param>
+            <param optional="false,true"><type>uint32_t</type>* <name>pSurfaceFormatCount</name></param>
+            <param optional="true" len="pSurfaceFormatCount"><type>VkSurfaceFormat2KHR</type>* <name>pSurfaceFormats</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkGetBufferMemoryRequirements2KHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkBufferMemoryRequirementsInfo2KHR</type>* <name>pInfo</name></param>
+            <param><type>VkMemoryRequirements2KHR</type>* <name>pMemoryRequirements</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkGetImageMemoryRequirements2KHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkImageMemoryRequirementsInfo2KHR</type>* <name>pInfo</name></param>
+            <param><type>VkMemoryRequirements2KHR</type>* <name>pMemoryRequirements</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkGetImageSparseMemoryRequirements2KHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkImageSparseMemoryRequirementsInfo2KHR</type>* <name>pInfo</name></param>
+            <param optional="false,true"><type>uint32_t</type>* <name>pSparseMemoryRequirementCount</name></param>
+            <param optional="true" len="pSparseMemoryRequirementCount"><type>VkSparseImageMemoryRequirements2KHR</type>* <name>pSparseMemoryRequirements</name></param>
+        </command>
     </commands>
 
-    <!-- SECTION: Vulkan API interface definitions -->
-    <feature api="vulkan" name="VK_VERSION_1_0" number="1.0">
+    <feature api="vulkan" name="VK_VERSION_1_0" number="1.0" comment="Vulkan core API interface definitions">
         <require comment="Header boilerplate">
             <type name="vk_platform"/>
         </require>
@@ -4080,23 +5355,18 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <command name="vkCmdEndRenderPass"/>
             <command name="vkCmdExecuteCommands"/>
         </require>
-        <require comment="Types not directly used by the API">
-            <!-- Include <type name="typename"/> here for e.g. structs that
-                 are not parameter types of commands, but still need to be
-                 defined in the API.
-             -->
+        <require comment="Types not directly used by the API. Include e.g. structs that are not parameter types of commands, but still defined by the API.">
             <type name="VkBufferMemoryBarrier"/>
             <type name="VkDispatchIndirectCommand"/>
             <type name="VkDrawIndexedIndirectCommand"/>
             <type name="VkDrawIndirectCommand"/>
             <type name="VkImageMemoryBarrier"/>
             <type name="VkMemoryBarrier"/>
+            <type name="VkObjectType"/>
         </require>
     </feature>
 
-    <!-- SECTION: Vulkan extension interface definitions -->
-    <extensions>
-            <!-- WSI extensions -->
+    <extensions comment="Vulkan extension interface definitions">
         <extension name="VK_KHR_surface" number="1" type="instance" supported="vulkan">
             <require>
                 <enum value="25"                                        name="VK_KHR_SURFACE_SPEC_VERSION"/>
@@ -4104,6 +5374,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <enum offset="0" dir="-" extends="VkResult"             name="VK_ERROR_SURFACE_LOST_KHR"/>
                 <enum offset="1" dir="-" extends="VkResult"             name="VK_ERROR_NATIVE_WINDOW_IN_USE_KHR"/>
                 <enum value="VK_COLOR_SPACE_SRGB_NONLINEAR_KHR"         name="VK_COLORSPACE_SRGB_NONLINEAR_KHR"/>
+                <enum offset="0" extends="VkObjectType"                 name="VK_OBJECT_TYPE_SURFACE_KHR"                  comment="VkSurfaceKHR"/>
                 <command name="vkDestroySurfaceKHR"/>
                 <command name="vkGetPhysicalDeviceSurfaceSupportKHR"/>
                 <command name="vkGetPhysicalDeviceSurfaceCapabilitiesKHR"/>
@@ -4120,6 +5391,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <enum offset="2"         extends="VkImageLayout"        name="VK_IMAGE_LAYOUT_PRESENT_SRC_KHR"/>
                 <enum offset="3"         extends="VkResult"             name="VK_SUBOPTIMAL_KHR"/>
                 <enum offset="4" dir="-" extends="VkResult"             name="VK_ERROR_OUT_OF_DATE_KHR"/>
+                <enum offset="0" extends="VkObjectType"                 name="VK_OBJECT_TYPE_SWAPCHAIN_KHR"              comment="VkSwapchainKHR"/>
                 <command name="vkCreateSwapchainKHR"/>
                 <command name="vkDestroySwapchainKHR"/>
                 <command name="vkGetSwapchainImagesKHR"/>
@@ -4133,6 +5405,8 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <enum value="&quot;VK_KHR_display&quot;"                name="VK_KHR_DISPLAY_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DISPLAY_MODE_CREATE_INFO_KHR"/>
                 <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DISPLAY_SURFACE_CREATE_INFO_KHR"/>
+                <enum offset="0" extends="VkObjectType"                 name="VK_OBJECT_TYPE_DISPLAY_KHR"               comment="VkDisplayKHR"/>
+                <enum offset="1" extends="VkObjectType"                 name="VK_OBJECT_TYPE_DISPLAY_MODE_KHR"          comment="VkDisplayModeKHR"/>
                 <type name="VkDisplayPlaneAlphaFlagsKHR"/>
                 <type name="VkDisplayPlaneAlphaFlagBitsKHR"/>
                 <type name="VkDisplayPropertiesKHR"/>
@@ -4185,7 +5459,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </extension>
         <extension name="VK_KHR_wayland_surface" number="7" type="instance" requires="VK_KHR_surface" protect="VK_USE_PLATFORM_WAYLAND_KHR" supported="vulkan">
             <require>
-                <enum value="5"                                         name="VK_KHR_WAYLAND_SURFACE_SPEC_VERSION"/>
+                <enum value="6"                                         name="VK_KHR_WAYLAND_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_wayland_surface&quot;"        name="VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR"/>
                 <type name="VkWaylandSurfaceCreateFlagsKHR"/>
@@ -4217,7 +5491,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </extension>
         <extension name="VK_KHR_win32_surface" number="10" type="instance" requires="VK_KHR_surface" protect="VK_USE_PLATFORM_WIN32_KHR" supported="vulkan">
             <require>
-                <enum value="5"                                         name="VK_KHR_WIN32_SURFACE_SPEC_VERSION"/>
+                <enum value="6"                                         name="VK_KHR_WIN32_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_win32_surface&quot;"          name="VK_KHR_WIN32_SURFACE_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR"/>
                 <type name="VkWin32SurfaceCreateFlagsKHR"/>
@@ -4233,34 +5507,36 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <enum value="&quot;VK_ANDROID_native_buffer&quot;"      name="VK_ANDROID_NATIVE_BUFFER_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_debug_report" number="12" type="instance" author="Google, Inc." contact="Courtney Goeltzenleuchter @courtney" supported="vulkan">
+        <extension name="VK_EXT_debug_report" number="12" type="instance" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtney" supported="vulkan">
             <require>
-                <enum value="4"                                         name="VK_EXT_DEBUG_REPORT_SPEC_VERSION"/>
+                <enum value="8"                                         name="VK_EXT_DEBUG_REPORT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_debug_report&quot;"           name="VK_EXT_DEBUG_REPORT_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT"/>
                 <enum offset="1" dir="-" extends="VkResult"             name="VK_ERROR_VALIDATION_FAILED_EXT"/>
                 <enum value="VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT" name="VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT"/>
+                <enum offset="0" extends="VkObjectType"                 name="VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT"          comment="VkDebugReportCallbackEXT"/>
+                <enum value="VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT"         name="VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT"/>
                 <type name="VkDebugReportObjectTypeEXT"/>
-                <type name="VkDebugReportErrorEXT"/>
+                <type name="VkDebugReportCallbackCreateInfoEXT"/>
                 <command name="vkCreateDebugReportCallbackEXT"/>
                 <command name="vkDestroyDebugReportCallbackEXT"/>
                 <command name="vkDebugReportMessageEXT"/>
             </require>
         </extension>
-        <extension name="VK_NV_glsl_shader" number="13" type="device" author="NVIDIA" contact="Piers Daniell @pdaniell" supported="vulkan">
+        <extension name="VK_NV_glsl_shader" number="13" type="device" author="NV" contact="Piers Daniell @pdaniell" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_GLSL_SHADER_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_glsl_shader&quot;"             name="VK_NV_GLSL_SHADER_EXTENSION_NAME"/>
                 <enum offset="0" dir="-" extends="VkResult"             name="VK_ERROR_INVALID_SHADER_NV"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_1" number="14" author="NVIDIA" contact="Piers Daniell @pdaniell" supported="disabled">
+        <extension name="VK_EXT_depth_range_unrestricted" type="device" number="14" author="NV" contact="Piers Daniell @pdaniell" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_NV_EXTENSION_1_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_1&quot;"             name="VK_NV_EXTENSION_1_EXTENSION_NAME"/>
-                <enum offset="0" dir="-" extends="VkResult"             name="VK_NV_EXTENSION_1_ERROR"/>
+                <enum value="1"                                         name="VK_EXT_DEPTH_RANGE_UNRESTRICTED_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_depth_range_unrestricted&quot;"             name="VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME"/>
             </require>
         </extension>
+
         <extension name="VK_KHR_sampler_mirror_clamp_to_edge" type="device" number="15" author="KHR" contact="Tobias Hector @tobias" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_SPEC_VERSION"/>
@@ -4311,17 +5587,18 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </extension>
         <extension name="VK_AMD_shader_explicit_vertex_parameter" number="22" type="device" author="AMD" contact="quentin.lin@amd.com" supported="vulkan">
             <require>
-                <enum value="1"                                                   name="VK_AMD_SHADER_EXPLICIT_VERTEX_PARAMETER_SPEC_VERSION"/>
+                <enum value="1"                                         name="VK_AMD_SHADER_EXPLICIT_VERTEX_PARAMETER_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_shader_explicit_vertex_parameter&quot;" name="VK_AMD_SHADER_EXPLICIT_VERTEX_PARAMETER_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_debug_marker" number="23" type="device" author="Baldur Karlsson" contact="baldurk@baldurk.org" supported="vulkan">
+        <extension name="VK_EXT_debug_marker" number="23" type="device" requires="VK_EXT_debug_report" author="Baldur Karlsson" contact="baldurk@baldurk.org" supported="vulkan">
             <require>
-                <enum value="3"                                         name="VK_EXT_DEBUG_MARKER_SPEC_VERSION"/>
+                <enum value="4"                                         name="VK_EXT_DEBUG_MARKER_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_debug_marker&quot;"           name="VK_EXT_DEBUG_MARKER_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT"/>
                 <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT"/>
                 <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT"/>
+                <type name="VkDebugReportObjectTypeEXT"/>
                 <type name="VkDebugMarkerObjectNameInfoEXT"/>
                 <type name="VkDebugMarkerObjectTagInfoEXT"/>
                 <type name="VkDebugMarkerMarkerInfoEXT"/>
@@ -4346,14 +5623,14 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </extension>
         <extension name="VK_AMD_gcn_shader" number="26" type="device" author="AMD" contact="dominik.witczak@amd.com" supported="vulkan">
             <require>
-                <enum value="1"                                        name="VK_AMD_GCN_SHADER_SPEC_VERSION"/>
-                <enum value="&quot;VK_AMD_gcn_shader&quot;"            name="VK_AMD_GCN_SHADER_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_AMD_GCN_SHADER_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_gcn_shader&quot;"             name="VK_AMD_GCN_SHADER_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NV_dedicated_allocation" number="27" type="device" author="NVIDIA" contact="Jeff Bolz @jbolz" supported="vulkan">
+        <extension name="VK_NV_dedicated_allocation" number="27" type="device" author="NV" contact="Jeff Bolz @jbolz" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_DEDICATED_ALLOCATION_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_dedicated_allocation&quot;" name="VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME"/>
+                <enum value="&quot;VK_NV_dedicated_allocation&quot;"    name="VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV"/>
                 <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV"/>
                 <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV"/>
@@ -4362,25 +5639,25 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <type name="VkDedicatedAllocationMemoryAllocateInfoNV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_28" number="28" author="NVIDIA" contact="Piers Daniell @pdaniell" supported="disabled">
+        <extension name="VK_EXT_extension_28" number="28" author="NV" contact="Piers Daniell @pdaniell" supported="disabled">
             <require>
                 <enum value="0"                                         name="VK_EXT_EXTENSION_28_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_extension_28&quot;"            name="VK_EXT_EXTENSION_28_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NVX_extension_29" number="29" author="NVIDIA" contact="Jeff Juliano @jjuliano" supported="disabled">
+        <extension name="VK_NVX_extension_29" number="29" author="NVX" contact="Jeff Juliano @jjuliano" supported="disabled">
             <require>
                 <enum value="0"                                         name="VK_NVX_EXTENSION_29_SPEC_VERSION"/>
                 <enum value="&quot;VK_NVX_extension_29&quot;"           name="VK_NVX_EXTENSION_29_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NVX_extension_30" number="30" author="NVIDIA" contact="Jeff Juliano @jjuliano" supported="disabled">
+        <extension name="VK_NVX_extension_30" number="30" author="NVX" contact="Jeff Juliano @jjuliano" supported="disabled">
             <require>
                 <enum value="0"                                         name="VK_NVX_EXTENSION_30_SPEC_VERSION"/>
                 <enum value="&quot;VK_NVX_extension_30&quot;"           name="VK_NVX_EXTENSION_30_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NVX_extension_31" number="31" author="NVIDIA" contact="Jeff Juliano @jjuliano" supported="disabled">
+        <extension name="VK_NVX_extension_31" number="31" author="NVX" contact="Jeff Juliano @jjuliano" supported="disabled">
             <require>
                 <enum value="0"                                         name="VK_NVX_EXTENSION_31_SPEC_VERSION"/>
                 <enum value="&quot;VK_NVX_extension_31&quot;"           name="VK_NVX_EXTENSION_31_EXTENSION_NAME"/>
@@ -4448,10 +5725,12 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <enum value="&quot;VK_AMD_extension_41&quot;"           name="VK_AMD_EXTENSION_41_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_AMD_extension_42" number="42" author="AMD" contact="Daniel Rakos @aqnuep" supported="disabled">
+        <extension name="VK_AMD_texture_gather_bias_lod" number="42" author="AMD" contact="Rex Xu @amdrexu" supported="vulkan" type="device" requires="VK_KHR_get_physical_device_properties2">
             <require>
-                <enum value="0"                                         name="VK_AMD_EXTENSION_42_SPEC_VERSION"/>
-                <enum value="&quot;VK_AMD_extension_42&quot;"           name="VK_AMD_EXTENSION_42_EXTENSION_NAME"/>
+                <enum value="1"                                          name="VK_AMD_TEXTURE_GATHER_BIAS_LOD_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_texture_gather_bias_lod&quot;" name="VK_AMD_TEXTURE_GATHER_BIAS_LOD_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"               name="VK_STRUCTURE_TYPE_TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD"/>
+                <type name="VkTextureLODGatherFormatPropertiesAMD"/>
             </require>
         </extension>
         <extension name="VK_AMD_extension_43" number="43" author="AMD" contact="Daniel Rakos @aqnuep" supported="disabled">
@@ -4484,7 +5763,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <enum value="&quot;VK_AMD_extension_47&quot;"           name="VK_AMD_EXTENSION_47_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NVX_extension_48" number="48" author="NVIDIA" contact="James Jones @cubanismo" supported="disabled">
+        <extension name="VK_NVX_extension_48" number="48" author="NVX" contact="James Jones @cubanismo" supported="disabled">
             <require>
                 <enum value="0"                                         name="VK_NVX_EXTENSION_48_SPEC_VERSION"/>
                 <enum value="&quot;VK_NVX_extension_48&quot;"           name="VK_NVX_EXTENSION_48_EXTENSION_NAME"/>
@@ -4502,28 +5781,35 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <enum value="&quot;VK_GOOGLE_extension_50&quot;"        name="VK_GOOGLE_EXTENSION_50_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NVX_extension_51" number="51" author="NVIDIA" contact="James Jones @cubanismo" supported="disabled">
+        <extension name="VK_NVX_extension_51" number="51" author="NVX" contact="James Jones @cubanismo" supported="disabled">
             <require>
                 <enum value="0"                                         name="VK_NVX_EXTENSION_51_SPEC_VERSION"/>
                 <enum value="&quot;VK_NVX_extension_51&quot;"           name="VK_NVX_EXTENSION_51_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NVX_extension_52" number="52" author="NVIDIA" contact="James Jones @cubanismo" supported="disabled">
+        <extension name="VK_NVX_extension_52" number="52" author="NVX" contact="James Jones @cubanismo" supported="disabled">
             <require>
                 <enum value="0"                                         name="VK_NVX_EXTENSION_52_SPEC_VERSION"/>
                 <enum value="&quot;VK_NVX_extension_52&quot;"           name="VK_NVX_EXTENSION_52_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_53" number="53" author="NVIDIA" contact="Jeff Bolz @jbolz" supported="disabled">
+        <extension name="VK_NV_extension_53" number="53" author="NV" contact="Jeff Bolz @jbolz" supported="disabled">
             <require>
                 <enum value="0"                                         name="VK_NV_EXTENSION_53_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_extension_53&quot;"            name="VK_NV_EXTENSION_53_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_54" number="54" author="NVIDIA" contact="Jeff Bolz @jbolz" supported="disabled">
+        <extension name="VK_KHX_multiview" number="54" type="device" author="NV" requires="VK_KHR_get_physical_device_properties2" contact="Jeff Bolz @jbolz" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_NV_EXTENSION_54_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_54&quot;"            name="VK_NV_EXTENSION_54_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHX_MULTIVIEW_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHX_multiview&quot;"              name="VK_KHX_MULTIVIEW_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO_KHX"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHX"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES_KHX"/>
+                <enum bitpos="1" extends="VkDependencyFlagBits"         name="VK_DEPENDENCY_VIEW_LOCAL_BIT_KHX"/>
+                <type name="VkRenderPassMultiviewCreateInfoKHX"/>
+                <type name="VkPhysicalDeviceMultiviewFeaturesKHX"/>
+                <type name="VkPhysicalDeviceMultiviewPropertiesKHX"/>
             </require>
         </extension>
         <extension name="VK_IMG_format_pvrtc" number="55" type="device" author="IMG" contact="Tobias Hector @tobias" supported="vulkan">
@@ -4540,7 +5826,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <enum offset="7" extends="VkFormat"                     name="VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG"/>
             </require>
         </extension>
-        <extension name="VK_NV_external_memory_capabilities" number="56" type="instance" author="NVIDIA" contact="James jones @cubanismo" supported="vulkan">
+        <extension name="VK_NV_external_memory_capabilities" number="56" type="instance" author="NV" contact="James Jones @cubanismo" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_EXTERNAL_MEMORY_CAPABILITIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_external_memory_capabilities&quot;" name="VK_NV_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME"/>
@@ -4552,7 +5838,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <command name="vkGetPhysicalDeviceExternalImageFormatPropertiesNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_external_memory" number="57" type="device" requires="VK_NV_external_memory_capabilities" author="NVIDIA" contact="James jones @cubanismo" supported="vulkan">
+        <extension name="VK_NV_external_memory" number="57" type="device" requires="VK_NV_external_memory_capabilities" author="NV" contact="James Jones @cubanismo" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_EXTERNAL_MEMORY_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_external_memory&quot;"         name="VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME"/>
@@ -4562,7 +5848,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <type name="VkExportMemoryAllocateInfoNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_external_memory_win32" number="58" type="device" requires="VK_NV_external_memory_capabilities,VK_NV_external_memory" author="NVIDIA" contact="James jones @cubanismo" protect="VK_USE_PLATFORM_WIN32_KHR" supported="vulkan">
+        <extension name="VK_NV_external_memory_win32" number="58" type="device" requires="VK_NV_external_memory_capabilities,VK_NV_external_memory" author="NV" contact="James Jones @cubanismo" protect="VK_USE_PLATFORM_WIN32_KHR" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_EXTERNAL_MEMORY_WIN32_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_external_memory_win32&quot;"   name="VK_NV_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME"/>
@@ -4573,7 +5859,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <command name="vkGetMemoryWin32HandleNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_win32_keyed_mutex" number="59" type="device" requires="VK_NV_external_memory_capabilities,VK_NV_external_memory_win32" author="NVIDIA" contact="Carsten Rohde" protect="VK_USE_PLATFORM_WIN32_KHR" supported="vulkan">
+        <extension name="VK_NV_win32_keyed_mutex" number="59" type="device" requires="VK_NV_external_memory_capabilities,VK_NV_external_memory_win32" author="NV" contact="Carsten Rohde" protect="VK_USE_PLATFORM_WIN32_KHR" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_WIN32_KEYED_MUTEX_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_win32_keyed_mutex&quot;"       name="VK_NV_WIN32_KEYED_MUTEX_EXTENSION_NAME"/>
@@ -4581,48 +5867,123 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <type name="VkWin32KeyedMutexAcquireReleaseInfoNV"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_60" number="60" author="KHR" contact="Jeff Bolz @jbolz" supported="disabled">
+        <extension name="VK_KHR_get_physical_device_properties2" number="60" type="instance" author="KHR" contact="Jeff Bolz @jbolz" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_60_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_60&quot;"           name="VK_KHR_EXTENSION_60_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_get_physical_device_properties2&quot;" name="VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2_KHR"/>
+                <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2_KHR"/>
+                <enum offset="5" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2_KHR"/>
+                <enum offset="6" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2_KHR"/>
+                <enum offset="7" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2_KHR"/>
+                <enum offset="8" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2_KHR"/>
+                <type name="VkPhysicalDeviceFeatures2KHR"/>
+                <type name="VkPhysicalDeviceProperties2KHR"/>
+                <type name="VkFormatProperties2KHR"/>
+                <type name="VkImageFormatProperties2KHR"/>
+                <type name="VkPhysicalDeviceImageFormatInfo2KHR"/>
+                <type name="VkQueueFamilyProperties2KHR"/>
+                <type name="VkPhysicalDeviceMemoryProperties2KHR"/>
+                <type name="VkSparseImageFormatProperties2KHR"/>
+                <type name="VkPhysicalDeviceSparseImageFormatInfo2KHR"/>
+                <command name="vkGetPhysicalDeviceFeatures2KHR"/>
+                <command name="vkGetPhysicalDeviceProperties2KHR"/>
+                <command name="vkGetPhysicalDeviceFormatProperties2KHR"/>
+                <command name="vkGetPhysicalDeviceImageFormatProperties2KHR"/>
+                <command name="vkGetPhysicalDeviceQueueFamilyProperties2KHR"/>
+                <command name="vkGetPhysicalDeviceMemoryProperties2KHR"/>
+                <command name="vkGetPhysicalDeviceSparseImageFormatProperties2KHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_61" number="61" author="KHR" contact="Jeff Bolz @jbolz" supported="disabled">
+        <extension name="VK_KHX_device_group" number="61" type="device" author="KHX" requires="VK_KHR_swapchain,VK_KHX_device_group_creation" contact="Jeff Bolz @jbolz" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_61_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_61&quot;"           name="VK_KHR_EXTENSION_61_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHX_DEVICE_GROUP_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHX_device_group&quot;"           name="VK_KHX_DEVICE_GROUP_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO_KHX"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_INFO_KHX"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO_KHX"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEVICE_GROUP_RENDER_PASS_BEGIN_INFO_KHX"/>
+                <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEVICE_GROUP_COMMAND_BUFFER_BEGIN_INFO_KHX"/>
+                <enum offset="5" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEVICE_GROUP_SUBMIT_INFO_KHX"/>
+                <enum offset="6" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEVICE_GROUP_BIND_SPARSE_INFO_KHX"/>
+                <enum offset="7" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_CAPABILITIES_KHX"/>
+                <enum offset="8" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMAGE_SWAPCHAIN_CREATE_INFO_KHX"/>
+                <enum offset="9" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHX"/>
+                <enum offset="10" extends="VkStructureType"             name="VK_STRUCTURE_TYPE_ACQUIRE_NEXT_IMAGE_INFO_KHX"/>
+                <enum offset="11" extends="VkStructureType"             name="VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_INFO_KHX"/>
+                <enum offset="12" extends="VkStructureType"             name="VK_STRUCTURE_TYPE_DEVICE_GROUP_SWAPCHAIN_CREATE_INFO_KHX"/>
+                <type name="VkPeerMemoryFeatureFlagsKHX"/>
+                <type name="VkPeerMemoryFeatureFlagBitsKHX"/>
+                <type name="VkMemoryAllocateFlagsKHX"/>
+                <type name="VkMemoryAllocateFlagBitsKHX"/>
+                <type name="VkDeviceGroupPresentModeFlagBitsKHX"/>
+                <type name="VkDeviceGroupPresentModeFlagsKHX"/>
+                <type name="VkMemoryAllocateFlagsInfoKHX"/>
+                <type name="VkBindBufferMemoryInfoKHX"/>
+                <type name="VkBindImageMemoryInfoKHX"/>
+                <type name="VkDeviceGroupRenderPassBeginInfoKHX"/>
+                <type name="VkDeviceGroupCommandBufferBeginInfoKHX"/>
+                <type name="VkDeviceGroupSubmitInfoKHX"/>
+                <type name="VkDeviceGroupBindSparseInfoKHX"/>
+                <type name="VkDeviceGroupPresentCapabilitiesKHX"/>
+                <type name="VkImageSwapchainCreateInfoKHX"/>
+                <type name="VkBindImageMemorySwapchainInfoKHX"/>
+                <type name="VkAcquireNextImageInfoKHX"/>
+                <type name="VkDeviceGroupPresentInfoKHX"/>
+                <type name="VkDeviceGroupSwapchainCreateInfoKHX"/>
+                <command name="vkGetDeviceGroupPeerMemoryFeaturesKHX"/>
+                <command name="vkBindBufferMemory2KHX"/>
+                <command name="vkBindImageMemory2KHX"/>
+                <command name="vkCmdSetDeviceMaskKHX"/>
+                <command name="vkGetDeviceGroupPresentCapabilitiesKHX"/>
+                <command name="vkGetDeviceGroupSurfacePresentModesKHX"/>
+                <command name="vkAcquireNextImage2KHX"/>
+                <command name="vkCmdDispatchBaseKHX"/>
+                <command name="vkGetPhysicalDevicePresentRectanglesKHX"/>
+                <enum bitpos="6" extends="VkImageCreateFlagBits"  name="VK_IMAGE_CREATE_BIND_SFR_BIT_KHX"    comment="Allows using VkBindImageMemoryInfoKHX::pSFRRects when binding memory to the image"/>
+                <enum bitpos="3" extends="VkPipelineCreateFlagBits"  name="VK_PIPELINE_CREATE_VIEW_INDEX_FROM_DEVICE_INDEX_BIT_KHX"/>
+                <enum bitpos="4" extends="VkPipelineCreateFlagBits"  name="VK_PIPELINE_CREATE_DISPATCH_BASE_KHX"/>
+                <enum bitpos="2" extends="VkDependencyFlagBits"   name="VK_DEPENDENCY_DEVICE_GROUP_BIT_KHX"      comment="Dependency is across devices"/>
+                <enum bitpos="0" extends="VkSwapchainCreateFlagBitsKHR" name="VK_SWAPCHAIN_CREATE_BIND_SFR_BIT_KHX" comment="Allow images with VK_IMAGE_CREATE_BIND_SFR_BIT_KHX"/>
             </require>
         </extension>
-        <extension name="VK_EXT_validation_flags" number="62" type="instance" author="Google, Inc." contact="Tobin Ehlis @tobine" supported="vulkan">
+        <extension name="VK_EXT_validation_flags" number="62" type="instance" author="GOOGLE" contact="Tobin Ehlis @tobine" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_EXT_VALIDATION_FLAGS_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_validation_flags&quot;"           name="VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME"/>
+                <enum value="&quot;VK_EXT_validation_flags&quot;"       name="VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT"/>
                 <type name="VkValidationFlagsEXT"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_63" number="63" author="NVIDIA" contact="Mathias Heyer @mheyer" supported="disabled">
+        <extension name="VK_NN_vi_surface" number="63" type="instance" author="NN" contact="Mathias Heyer @mheyer" requires="VK_KHR_surface" protect="VK_USE_PLATFORM_VI_NN" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_NV_EXTENSION_63_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_63&quot;"            name="VK_NV_EXTENSION_63_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_NN_VI_SURFACE_SPEC_VERSION"/>
+                <enum value="&quot;VK_NN_vi_surface&quot;"              name="VK_NN_VI_SURFACE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VI_SURFACE_CREATE_INFO_NN"/>
+                <type name="VkViSurfaceCreateFlagsNN"/>
+                <type name="VkViSurfaceCreateInfoNN"/>
+                <command name="vkCreateViSurfaceNN"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_64" number="64" author="KHR" contact="Daniel Koch @dgkoch" supported="disabled">
+        <extension name="VK_KHR_shader_draw_parameters" number="64" type="device" author="KHR" contact="Daniel Koch @dgkoch" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_64_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_64&quot;"           name="VK_KHR_EXTENSION_64_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_SHADER_DRAW_PARAMETERS_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_shader_draw_parameters&quot;" name="VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_65" number="65" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
+        <extension name="VK_EXT_shader_subgroup_ballot" number="65" type="device" author="NV" contact="Daniel Koch @dgkoch" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_NV_EXTENSION_65_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_65&quot;"            name="VK_NV_EXTENSION_65_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_EXT_SHADER_SUBGROUP_BALLOT_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_shader_subgroup_ballot&quot;" name="VK_EXT_SHADER_SUBGROUP_BALLOT_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_66" number="66" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
+        <extension name="VK_EXT_shader_subgroup_vote" number="66" type="device" author="NV" contact="Daniel Koch @dgkoch" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_NV_EXTENSION_66_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_66&quot;"            name="VK_NV_EXTENSION_66_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_EXT_SHADER_SUBGROUP_VOTE_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_shader_subgroup_vote&quot;"   name="VK_EXT_SHADER_SUBGROUP_VOTE_EXTENSION_NAME"/>
             </require>
         </extension>
         <extension name="VK_ARM_extension_01" number="67" type="device" author="ARM" contact="Jan-Harald Fredriksen @janharald" supported="disabled">
@@ -4643,76 +6004,168 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <enum value="&quot;VK_IMG_extension_69&quot;"           name="VK_IMG_EXTENSION_69_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_70" number="70" author="KHR" contact="Piers Daniell @pdaniell" supported="disabled">
+        <extension name="VK_KHR_maintenance1" number="70" type="device" author="KHR" contact="Piers Daniell @pdaniell" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_70_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_70&quot;"           name="VK_KHR_EXTENSION_70_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_MAINTENANCE1_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_maintenance1&quot;"           name="VK_KHR_MAINTENANCE1_EXTENSION_NAME"/>
+                <enum offset="0" dir="-" extends="VkResult"             name="VK_ERROR_OUT_OF_POOL_MEMORY_KHR"/>
+                <enum bitpos="14" extends="VkFormatFeatureFlagBits"     name="VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR" comment="Format can be used as the source image of image transfer commands"/>
+                <enum bitpos="15" extends="VkFormatFeatureFlagBits"     name="VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR" comment="Format can be used as the destination image of image transfer commands"/>
+                <enum bitpos="5" extends="VkImageCreateFlagBits"        name="VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR" comment="The 3D image can be viewed as a 2D or 2D array image"/>
+                <command name="vkTrimCommandPoolKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_71" number="71" author="KHR" contact="Jeff Bolz @jbolz" supported="disabled">
+        <extension name="VK_KHX_device_group_creation" number="71" type="instance" author="KHX" contact="Jeff Bolz @jbolz" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_71_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_71&quot;"           name="VK_KHR_EXTENSION_71_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHX_DEVICE_GROUP_CREATION_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHX_device_group_creation&quot;"  name="VK_KHX_DEVICE_GROUP_CREATION_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES_KHX"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO_KHX"/>
+                <enum name="VK_MAX_DEVICE_GROUP_SIZE_KHX"/>
+                <type name="VkPhysicalDeviceGroupPropertiesKHX"/>
+                <type name="VkDeviceGroupDeviceCreateInfoKHX"/>
+                <command name="vkEnumeratePhysicalDeviceGroupsKHX"/>
+                <enum bitpos="1" extends="VkMemoryHeapFlagBits"         name="VK_MEMORY_HEAP_MULTI_INSTANCE_BIT_KHX" comment="If set, heap allocations allocate multiple instances by default"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_72" number="72" author="KHR" contact="James Jones @cubanismo" supported="disable">
+        <extension name="VK_KHR_external_memory_capabilities" number="72" type="instance" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="James Jones @cubanismo" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_72_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_72&quot;"           name="VK_KHR_EXTENSION_72_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_external_memory_capabilities&quot;" name="VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES_KHR"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO_KHR"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES_KHR"/>
+                <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES_KHR"/>
+                <enum name="VK_LUID_SIZE_KHR"/>
+                <type name="VkExternalMemoryHandleTypeFlagsKHR"/>
+                <type name="VkExternalMemoryHandleTypeFlagBitsKHR"/>
+                <type name="VkExternalMemoryFeatureFlagsKHR"/>
+                <type name="VkExternalMemoryFeatureFlagBitsKHR"/>
+                <type name="VkExternalMemoryPropertiesKHR"/>
+                <type name="VkPhysicalDeviceExternalImageFormatInfoKHR"/>
+                <type name="VkExternalImageFormatPropertiesKHR"/>
+                <type name="VkPhysicalDeviceExternalBufferInfoKHR"/>
+                <type name="VkExternalBufferPropertiesKHR"/>
+                <type name="VkPhysicalDeviceIDPropertiesKHR"/>
+                <command name="vkGetPhysicalDeviceExternalBufferPropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_73" number="73" author="KHR" contact="James Jones @cubanismo" supported="disable">
+        <extension name="VK_KHR_external_memory" number="73" type="device" requires="VK_KHR_external_memory_capabilities" author="KHR" contact="James Jones @cubanismo" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_73_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_73&quot;"           name="VK_KHR_EXTENSION_73_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_EXTERNAL_MEMORY_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_external_memory&quot;"        name="VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_KHR"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR"/>
+                <enum offset="3" dir="-" extends="VkResult"             name="VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR"/>
+                <enum name="VK_QUEUE_FAMILY_EXTERNAL_KHR"/>
+                <type name="VkExternalMemoryImageCreateInfoKHR"/>
+                <type name="VkExternalMemoryBufferCreateInfoKHR"/>
+                <type name="VkExportMemoryAllocateInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_74" number="74" author="KHR" contact="James Jones @cubanismo" supported="disable">
+        <extension name="VK_KHR_external_memory_win32" number="74" type="device" requires="VK_KHR_external_memory_capabilities,VK_KHR_external_memory" author="KHR" contact="James Jones @cubanismo" protect="VK_USE_PLATFORM_WIN32_KHR" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_74_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_74&quot;"           name="VK_KHR_EXTENSION_74_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_EXTERNAL_MEMORY_WIN32_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_external_memory_win32&quot;"  name="VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR"/>
+                <type name="VkImportMemoryWin32HandleInfoKHR"/>
+                <type name="VkExportMemoryWin32HandleInfoKHR"/>
+                <type name="VkMemoryWin32HandlePropertiesKHR"/>
+                <type name="VkMemoryGetWin32HandleInfoKHR"/>
+                <command name="vkGetMemoryWin32HandleKHR"/>
+                <command name="vkGetMemoryWin32HandlePropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_75" number="75" author="KHR" contact="James Jones @cubanismo" supported="disable">
+        <extension name="VK_KHR_external_memory_fd" number="75" type="device" requires="VK_KHR_external_memory_capabilities,VK_KHR_external_memory" author="KHX" contact="James Jones @cubanismo" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_75_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_75&quot;"           name="VK_KHR_EXTENSION_75_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_EXTERNAL_MEMORY_FD_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_external_memory_fd&quot;"     name="VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR"/>
+                <type name="VkImportMemoryFdInfoKHR"/>
+                <type name="VkMemoryFdPropertiesKHR"/>
+                <type name="VkMemoryGetFdInfoKHR"/>
+                <command name="vkGetMemoryFdKHR"/>
+                <command name="vkGetMemoryFdPropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_76" number="76" author="KHR" contact="James Jones @cubanismo" supported="disable">
+        <extension name="VK_KHR_win32_keyed_mutex" number="76" type="device" requires="VK_KHR_external_memory_capabilities,VK_KHR_external_memory,VK_KHR_external_memory_win32" author="KHR" contact="Carsten Rohde" protect="VK_USE_PLATFORM_WIN32_KHR" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_76_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_76&quot;"           name="VK_KHR_EXTENSION_76_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_WIN32_KEYED_MUTEX_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_win32_keyed_mutex&quot;"      name="VK_KHR_WIN32_KEYED_MUTEX_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR"/>
+                <type name="VkWin32KeyedMutexAcquireReleaseInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_77" number="77" author="KHR" contact="James Jones @cubanismo" supported="disable">
+        <extension name="VK_KHR_external_semaphore_capabilities" number="77" type="instance" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="James Jones @cubanismo" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_77_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_77&quot;"           name="VK_KHR_EXTENSION_77_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_external_semaphore_capabilities&quot;" name="VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES_KHR"/>
+                <enum name="VK_LUID_SIZE_KHR"/>
+                <type name="VkExternalSemaphoreHandleTypeFlagsKHR"/>
+                <type name="VkExternalSemaphoreHandleTypeFlagBitsKHR"/>
+                <type name="VkExternalSemaphoreFeatureFlagsKHR"/>
+                <type name="VkExternalSemaphoreFeatureFlagBitsKHR"/>
+                <type name="VkPhysicalDeviceExternalSemaphoreInfoKHR"/>
+                <type name="VkExternalSemaphorePropertiesKHR"/>
+                <type name="VkPhysicalDeviceIDPropertiesKHR"/>
+                <command name="vkGetPhysicalDeviceExternalSemaphorePropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_78" number="78" author="KHR" contact="James Jones @cubanismo" supported="disable">
+        <extension name="VK_KHR_external_semaphore" number="78" type="device" requires="VK_KHR_external_semaphore_capabilities" author="KHR" contact="James Jones @cubanismo" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_78_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_78&quot;"           name="VK_KHR_EXTENSION_78_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_EXTERNAL_SEMAPHORE_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_external_semaphore&quot;"     name="VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO_KHR"/>
+                <type name="VkSemaphoreImportFlagsKHR"/>
+                <type name="VkSemaphoreImportFlagBitsKHR"/>
+                <type name="VkExportSemaphoreCreateInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_79" number="79" author="KHR" contact="James Jones @cubanismo" supported="disable">
+        <extension name="VK_KHR_external_semaphore_win32" number="79" type="device" requires="VK_KHR_external_semaphore_capabilities,VK_KHR_external_semaphore" author="KHR" contact="James Jones @cubanismo" protect="VK_USE_PLATFORM_WIN32_KHR" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_79_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_79&quot;"           name="VK_KHR_EXTENSION_79_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_EXTERNAL_SEMAPHORE_WIN32_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_external_semaphore_win32&quot;" name="VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR"/>
+                <type name="VkImportSemaphoreWin32HandleInfoKHR"/>
+                <type name="VkExportSemaphoreWin32HandleInfoKHR"/>
+                <type name="VkD3D12FenceSubmitInfoKHR"/>
+                <type name="VkSemaphoreGetWin32HandleInfoKHR"/>
+                <command name="vkImportSemaphoreWin32HandleKHR"/>
+                <command name="vkGetSemaphoreWin32HandleKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_80" number="80" author="KHR" contact="James Jones @cubanismo" supported="disable">
+        <extension name="VK_KHR_external_semaphore_fd" number="80" type="device" requires="VK_KHR_external_semaphore_capabilities,VK_KHR_external_semaphore" author="KHR" contact="James Jones @cubanismo" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_80_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_80&quot;"           name="VK_KHR_EXTENSION_80_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_EXTERNAL_SEMAPHORE_FD_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_external_semaphore_fd&quot;"  name="VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR"/>
+                <type name="VkImportSemaphoreFdInfoKHR"/>
+                <type name="VkSemaphoreGetFdInfoKHR"/>
+                <command name="vkImportSemaphoreFdKHR"/>
+                <command name="vkGetSemaphoreFdKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_81" number="81" author="KHR" contact="Jeff Bolz @jbolz" supported="disabled">
+        <extension name="VK_KHR_push_descriptor" number="81" type="device" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="Jeff Bolz @jbolz" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_81_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_81&quot;"           name="VK_KHR_EXTENSION_81_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_PUSH_DESCRIPTOR_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_push_descriptor&quot;"        name="VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR"/>
+                <enum bitpos="0" extends="VkDescriptorSetLayoutCreateFlagBits"   name="VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR"  comment="Descriptors are pushed via flink:vkCmdPushDescriptorSetKHR"/>
+                <command name="vkCmdPushDescriptorSetKHR"/>
+                <type name="VkPhysicalDevicePushDescriptorPropertiesKHR"/>
             </require>
         </extension>
         <extension name="VK_KHR_extension_82" number="82" author="KHR" contact="Jeff Bolz @jbolz" supported="disabled">
@@ -4722,182 +6175,788 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             </require>
         </extension>
         <extension name="VK_KHR_extension_83" number="83" author="KHR" contact="Jan-Harald Fredriksen @janharald" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_83_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_83&quot;"           name="VK_KHR_EXTENSION_83_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_84" number="84" author="KHR" contact="Jan-Harald Fredriksen @janharald" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_84_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_84&quot;"           name="VK_KHR_EXTENSION_84_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_85" number="85" author="KHR" contact="Ian Elliott @ianelliott" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_85_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_85&quot;"           name="VK_KHR_EXTENSION_85_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_86" number="86" author="KHR" contact="Markus Tavenrath @mtavenrath" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_86_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_86&quot;"           name="VK_KHR_EXTENSION_86_EXTENSION_NAME"/>
-              </require>
-         </extension>
-        <extension name="VK_NVX_device_generated_commands" number="87" type="device" author="NVIDIA" contact="Christoph Kubisch @pixeljetstream" supported="vulkan">
-          <require>
-              <enum value="1"                                               name="VK_NVX_DEVICE_GENERATED_COMMANDS_SPEC_VERSION"/>
-              <enum value="&quot;VK_NVX_device_generated_commands&quot;"    name="VK_NVX_DEVICE_GENERATED_COMMANDS_EXTENSION_NAME"/>
-              <enum offset="0" extends="VkStructureType"                    name="VK_STRUCTURE_TYPE_OBJECT_TABLE_CREATE_INFO_NVX"/>
-              <enum offset="1" extends="VkStructureType"                    name="VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NVX"/>
-              <enum offset="2" extends="VkStructureType"                    name="VK_STRUCTURE_TYPE_CMD_PROCESS_COMMANDS_INFO_NVX"/>
-              <enum offset="3" extends="VkStructureType"                    name="VK_STRUCTURE_TYPE_CMD_RESERVE_SPACE_FOR_COMMANDS_INFO_NVX"/>
-              <enum offset="4" extends="VkStructureType"                    name="VK_STRUCTURE_TYPE_DEVICE_GENERATED_COMMANDS_LIMITS_NVX"/>
-              <enum offset="5" extends="VkStructureType"                    name="VK_STRUCTURE_TYPE_DEVICE_GENERATED_COMMANDS_FEATURES_NVX"/>
-              <enum bitpos="17" extends="VkPipelineStageFlagBits"           name="VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX"/>
-              <enum bitpos="17" extends="VkAccessFlagBits"                  name="VK_ACCESS_COMMAND_PROCESS_READ_BIT_NVX"/>
-              <enum bitpos="18" extends="VkAccessFlagBits"                  name="VK_ACCESS_COMMAND_PROCESS_WRITE_BIT_NVX"/>
-              <type name="VkObjectTableNVX"/>
-              <type name="VkIndirectCommandsLayoutNVX"/>
-              <type name="VkIndirectCommandsLayoutUsageFlagsNVX"/>
-              <type name="VkObjectEntryUsageFlagsNVX"/>
-              <type name="VkIndirectCommandsLayoutUsageFlagBitsNVX"/>
-              <type name="VkIndirectCommandsTokenTypeNVX"/>
-              <type name="VkObjectEntryUsageFlagBitsNVX"/>
-              <type name="VkObjectEntryTypeNVX"/>
-              <type name="VkDeviceGeneratedCommandsFeaturesNVX"/>
-              <type name="VkDeviceGeneratedCommandsLimitsNVX"/>
-              <type name="VkIndirectCommandsTokenNVX"/>
-              <type name="VkIndirectCommandsLayoutTokenNVX"/>
-              <type name="VkIndirectCommandsLayoutCreateInfoNVX"/>
-              <type name="VkCmdProcessCommandsInfoNVX"/>
-              <type name="VkCmdReserveSpaceForCommandsInfoNVX"/>
-              <type name="VkObjectTableCreateInfoNVX"/>
-              <type name="VkObjectTableEntryNVX"/>
-              <type name="VkObjectTablePipelineEntryNVX"/>
-              <type name="VkObjectTableDescriptorSetEntryNVX"/>
-              <type name="VkObjectTableVertexBufferEntryNVX"/>
-              <type name="VkObjectTableIndexBufferEntryNVX"/>
-              <type name="VkObjectTablePushConstantEntryNVX"/>
-              <command name="vkCmdProcessCommandsNVX"/>
-              <command name="vkCmdReserveSpaceForCommandsNVX"/>
-              <command name="vkCreateIndirectCommandsLayoutNVX"/>
-              <command name="vkDestroyIndirectCommandsLayoutNVX"/>
-              <command name="vkCreateObjectTableNVX"/>
-              <command name="vkDestroyObjectTableNVX"/>
-              <command name="vkRegisterObjectsNVX"/>
-              <command name="vkUnregisterObjectsNVX"/>
-              <command name="vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX"/>
-          </require>
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_83_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_83&quot;"           name="VK_KHR_EXTENSION_83_EXTENSION_NAME"/>
+            </require>
         </extension>
-         <extension name="VK_KHR_extension_88" number="88" author="NV" contact="Eric Werness @ewerness" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_88_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_88&quot;"           name="VK_KHR_EXTENSION_88_EXTENSION_NAME"/>
-              </require>
+        <extension name="VK_KHR_16bit_storage" number="84" type="device" requires="VK_KHR_get_physical_device_properties2,VK_KHR_storage_buffer_storage_class" author="KHR" contact="Jan-Harald Fredriksen @janharald" supported="vulkan">
+            <require>
+                <enum value="1"                                           name="VK_KHR_16BIT_STORAGE_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_16bit_storage&quot;"            name="VK_KHR_16BIT_STORAGE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES_KHR"/>
+                <type name="VkPhysicalDevice16BitStorageFeaturesKHR"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_incremental_present" number="85" type="device" author="KHR" requires="VK_KHR_swapchain" contact="Ian Elliott ianelliott@google.com" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_KHR_INCREMENTAL_PRESENT_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_incremental_present&quot;"    name="VK_KHR_INCREMENTAL_PRESENT_EXTENSION_NAME"/>
+                <enum offset="0"         extends="VkStructureType"      name="VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR"/>
+                <type name="VkPresentRegionsKHR"/>
+                <type name="VkPresentRegionKHR"/>
+                <type name="VkRectLayerKHR"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_descriptor_update_template" number="86" type="device" author="KHR" contact="Markus Tavenrath @mtavenrath" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_descriptor_update_template&quot;" name="VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR"/>
+                <enum offset="0" extends="VkDebugReportObjectTypeEXT"   name="VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR_EXT"/>
+                <enum offset="0" extends="VkObjectType"                 name="VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR"         comment="VkDescriptorUpdateTemplateKHR"/>
+                <command name="vkCreateDescriptorUpdateTemplateKHR"/>
+                <command name="vkDestroyDescriptorUpdateTemplateKHR"/>
+                <command name="vkUpdateDescriptorSetWithTemplateKHR"/>
+                <command name="vkCmdPushDescriptorSetWithTemplateKHR"/>
+                <type name="VkDescriptorUpdateTemplateKHR"/>
+                <type name="VkDescriptorUpdateTemplateCreateFlagsKHR"/>
+                <type name="VkDescriptorUpdateTemplateTypeKHR"/>
+                <type name="VkDescriptorUpdateTemplateEntryKHR"/>
+                <type name="VkDescriptorUpdateTemplateCreateInfoKHR"/>
+            </require>
+        </extension>
+        <extension name="VK_NVX_device_generated_commands" number="87" type="device" author="NVX" contact="Christoph Kubisch @pixeljetstream" supported="vulkan">
+            <require>
+                <enum value="3"                                         name="VK_NVX_DEVICE_GENERATED_COMMANDS_SPEC_VERSION"/>
+                <enum value="&quot;VK_NVX_device_generated_commands&quot;"    name="VK_NVX_DEVICE_GENERATED_COMMANDS_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_OBJECT_TABLE_CREATE_INFO_NVX"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NVX"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_CMD_PROCESS_COMMANDS_INFO_NVX"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_CMD_RESERVE_SPACE_FOR_COMMANDS_INFO_NVX"/>
+                <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEVICE_GENERATED_COMMANDS_LIMITS_NVX"/>
+                <enum offset="5" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEVICE_GENERATED_COMMANDS_FEATURES_NVX"/>
+                <enum bitpos="17" extends="VkPipelineStageFlagBits"     name="VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX"/>
+                <enum bitpos="17" extends="VkAccessFlagBits"            name="VK_ACCESS_COMMAND_PROCESS_READ_BIT_NVX"/>
+                <enum bitpos="18" extends="VkAccessFlagBits"            name="VK_ACCESS_COMMAND_PROCESS_WRITE_BIT_NVX"/>
+                <enum offset="0" extends="VkObjectType"                 name="VK_OBJECT_TYPE_OBJECT_TABLE_NVX"                     comment="VkobjectTableNVX"/>
+                <enum offset="1" extends="VkObjectType"                 name="VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NVX"         comment="VkIndirectCommandsLayoutNVX"/>
+                <type name="VkObjectTableNVX"/>
+                <type name="VkIndirectCommandsLayoutNVX"/>
+                <type name="VkIndirectCommandsLayoutUsageFlagsNVX"/>
+                <type name="VkObjectEntryUsageFlagsNVX"/>
+                <type name="VkIndirectCommandsLayoutUsageFlagBitsNVX"/>
+                <type name="VkIndirectCommandsTokenTypeNVX"/>
+                <type name="VkObjectEntryUsageFlagBitsNVX"/>
+                <type name="VkObjectEntryTypeNVX"/>
+                <type name="VkDeviceGeneratedCommandsFeaturesNVX"/>
+                <type name="VkDeviceGeneratedCommandsLimitsNVX"/>
+                <type name="VkIndirectCommandsTokenNVX"/>
+                <type name="VkIndirectCommandsLayoutTokenNVX"/>
+                <type name="VkIndirectCommandsLayoutCreateInfoNVX"/>
+                <type name="VkCmdProcessCommandsInfoNVX"/>
+                <type name="VkCmdReserveSpaceForCommandsInfoNVX"/>
+                <type name="VkObjectTableCreateInfoNVX"/>
+                <type name="VkObjectTableEntryNVX"/>
+                <type name="VkObjectTablePipelineEntryNVX"/>
+                <type name="VkObjectTableDescriptorSetEntryNVX"/>
+                <type name="VkObjectTableVertexBufferEntryNVX"/>
+                <type name="VkObjectTableIndexBufferEntryNVX"/>
+                <type name="VkObjectTablePushConstantEntryNVX"/>
+                <command name="vkCmdProcessCommandsNVX"/>
+                <command name="vkCmdReserveSpaceForCommandsNVX"/>
+                <command name="vkCreateIndirectCommandsLayoutNVX"/>
+                <command name="vkDestroyIndirectCommandsLayoutNVX"/>
+                <command name="vkCreateObjectTableNVX"/>
+                <command name="vkDestroyObjectTableNVX"/>
+                <command name="vkRegisterObjectsNVX"/>
+                <command name="vkUnregisterObjectsNVX"/>
+                <command name="vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_clip_space_w_scaling" number="88" type="device" author="NV" contact="Eric Werness @ewerness" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_NV_CLIP_SPACE_W_SCALING_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_clip_space_w_scaling&quot;"    name="VK_NV_CLIP_SPACE_W_SCALING_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV"/>
+                <enum offset="0" extends="VkDynamicState"               name="VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV"/>
+                <type name="VkViewportWScalingNV"/>
+                <type name="VkPipelineViewportWScalingStateCreateInfoNV"/>
+                <command name="vkCmdSetViewportWScalingNV"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_direct_mode_display" number="89" type="instance" requires="VK_KHR_display" author="NV" contact="James Jones @cubanismo" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_EXT_DIRECT_MODE_DISPLAY_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_direct_mode_display&quot;"    name="VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME"/>
+                <command name="vkReleaseDisplayEXT"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_acquire_xlib_display" number="90" type="instance" requires="VK_EXT_direct_mode_display,VK_KHR_display" author="NV" contact="James Jones @cubanismo" protect="VK_USE_PLATFORM_XLIB_XRANDR_EXT" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_EXT_ACQUIRE_XLIB_DISPLAY_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_acquire_xlib_display&quot;"   name="VK_EXT_ACQUIRE_XLIB_DISPLAY_EXTENSION_NAME"/>
+                <command name="vkAcquireXlibDisplayEXT"/>
+                <command name="vkGetRandROutputDisplayEXT"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_display_surface_counter" number="91" type="instance" requires="VK_KHR_display" author="NV" contact="James Jones @cubanismo" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_EXT_DISPLAY_SURFACE_COUNTER_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_display_surface_counter&quot;" name="VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES2_EXT"/>
+                <type name="VkSurfaceCounterFlagsEXT"/>
+                <type name="VkSurfaceCounterFlagBitsEXT"/>
+                <type name="VkSurfaceCapabilities2EXT"/>
+                <command name="vkGetPhysicalDeviceSurfaceCapabilities2EXT"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_display_control" number="92" type="device" requires="VK_KHR_display,VK_EXT_display_surface_counter,VK_KHR_swapchain" author="NV" contact="James Jones @cubanismo" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_EXT_DISPLAY_CONTROL_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_display_control&quot;"        name="VK_EXT_DISPLAY_CONTROL_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DISPLAY_POWER_INFO_EXT"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEVICE_EVENT_INFO_EXT"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DISPLAY_EVENT_INFO_EXT"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SWAPCHAIN_COUNTER_CREATE_INFO_EXT"/>
+                <type name="VkDisplayPowerStateEXT"/>
+                <type name="VkDeviceEventTypeEXT"/>
+                <type name="VkDisplayEventTypeEXT"/>
+                <type name="VkDisplayPowerInfoEXT"/>
+                <type name="VkDeviceEventInfoEXT"/>
+                <type name="VkDisplayEventInfoEXT"/>
+                <type name="VkSwapchainCounterCreateInfoEXT"/>
+                <command name="vkDisplayPowerControlEXT"/>
+                <command name="vkRegisterDeviceEventEXT"/>
+                <command name="vkRegisterDisplayEventEXT"/>
+                <command name="vkGetSwapchainCounterEXT"/>
+            </require>
+        </extension>
+        <extension name="VK_GOOGLE_display_timing" number="93" type="device" author="GOOGLE" requires="VK_KHR_swapchain" contact="Ian Elliott ianelliott@google.com" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_GOOGLE_DISPLAY_TIMING_SPEC_VERSION"/>
+                <enum value="&quot;VK_GOOGLE_display_timing&quot;"      name="VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME"/>
+                <enum offset="0"         extends="VkStructureType"      name="VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE"/>
+                <type name="VkRefreshCycleDurationGOOGLE"/>
+                <type name="VkPastPresentationTimingGOOGLE"/>
+                <type name="VkPresentTimesInfoGOOGLE"/>
+                <type name="VkPresentTimeGOOGLE"/>
+                <command name="vkGetRefreshCycleDurationGOOGLE"/>
+                <command name="vkGetPastPresentationTimingGOOGLE"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_94" number="94" author="Codeplay" contact="Neil Henning @neil_henning" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_94_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_94&quot;"           name="VK_KHR_EXTENSION_94_EXTENSION_NAME"/>
+            </require>
          </extension>
-         <extension name="VK_EXT_extension_89" number="89" author="NV" contact="James Jones @cubanismo" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_EXT_EXTENSION_89_SPEC_VERSION"/>
-                 <enum value="&quot;VK_EXT_extension_89&quot;"           name="VK_EXT_EXTENSION_89_EXTENSION_NAME"/>
-              </require>
-         </extension>
-         <extension name="VK_EXT_extension_90" number="90" author="NV" contact="James Jones @cubanismo" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_EXT_EXTENSION_90_SPEC_VERSION"/>
-                 <enum value="&quot;VK_EXT_extension_90&quot;"           name="VK_EXT_EXTENSION_90_EXTENSION_NAME"/>
-              </require>
-         </extension>
-         <extension name="VK_EXT_extension_91" number="91" author="NV" contact="James Jones @cubanismo" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_EXT_EXTENSION_91_SPEC_VERSION"/>
-                 <enum value="&quot;VK_EXT_extension_91&quot;"           name="VK_EXT_EXTENSION_91_EXTENSION_NAME"/>
-              </require>
-         </extension>
-         <extension name="VK_EXT_extension_92" number="92" author="NV" contact="James Jones @cubanismo" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_EXT_EXTENSION_92_SPEC_VERSION"/>
-                 <enum value="&quot;VK_EXT_extension_92&quot;"           name="VK_EXT_EXTENSION_92_EXTENSION_NAME"/>
-              </require>
-         </extension>
-         <extension name="VK_KHR_extension_93" number="93" author="GOOGLE" contact="Ian Elliott @ianelliott" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_GOOGLE_EXTENSION_93_SPEC_VERSION"/>
-                 <enum value="&quot;VK_GOOGLE_extension_93&quot;"        name="VK_GOOGLE_EXTENSION_93_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_94" number="94" author="Codeplay" contact="Neil Henning @neil_henning" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_94_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_94&quot;"           name="VK_KHR_EXTENSION_94_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_extension_95" number="95" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_NV_EXTENSION_95_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_extension_95&quot;"            name="VK_NV_EXTENSION_95_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_extension_96" number="96" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_NV_EXTENSION_96_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_extension_96&quot;"            name="VK_NV_EXTENSION_96_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_extension_97" number="97" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_NV_EXTENSION_97_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_extension_97&quot;"            name="VK_NV_EXTENSION_97_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_extension_98" number="98" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_NV_EXTENSION_98_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_extension_98&quot;"            name="VK_NV_EXTENSION_98_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_extension_99" number="99" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_NV_EXTENSION_99_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_extension_99&quot;"            name="VK_NV_EXTENSION_99_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_extension_100" number="100" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_NV_EXTENSION_100_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_extension_100&quot;"           name="VK_NV_EXTENSION_100_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_extension_101" number="101" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_NV_EXTENSION_101_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_extension_101&quot;"           name="VK_NV_EXTENSION_101_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_extension_102" number="102" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_NV_EXTENSION_102_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_extension_102&quot;"           name="VK_NV_EXTENSION_102_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_extension_103" number="103" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_NV_EXTENSION_103_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_extension_103&quot;"           name="VK_NV_EXTENSION_103_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_extension_104" number="104" author="NVIDIA" contact="Mathias Schott @mschott" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_NV_EXTENSION_104_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_extension_104&quot;"           name="VK_NV_EXTENSION_104_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_EXT_extension_105" number="105" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtneygo" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_105_SPEC_VERSION"/>
-                 <enum value="&quot;VK_EXT_extension_105&quot;"           name="VK_KHR_EXTENSION_105_EXTENSION_NAME"/>
-             </require>
-         </extension>
+        <extension name="VK_NV_sample_mask_override_coverage" number="95" type="device" author="NV" contact="Piers Daniell @pdaniell" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_sample_mask_override_coverage&quot;" name="VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_geometry_shader_passthrough" number="96" type="device" author="NV" contact="Daniel Koch @dgkoch" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_NV_GEOMETRY_SHADER_PASSTHROUGH_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_geometry_shader_passthrough&quot;" name="VK_NV_GEOMETRY_SHADER_PASSTHROUGH_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_viewport_array2" number="97" type="device" author="NV" contact="Daniel Koch @dgkoch" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_NV_VIEWPORT_ARRAY2_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_viewport_array2&quot;"         name="VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NVX_multiview_per_view_attributes" number="98" type="device" author="NVX" contact="Jeff Bolz @jbolz" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_NVX_MULTIVIEW_PER_VIEW_ATTRIBUTES_SPEC_VERSION"/>
+                <enum value="&quot;VK_NVX_multiview_per_view_attributes&quot;"  name="VK_NVX_MULTIVIEW_PER_VIEW_ATTRIBUTES_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX"/>
+                <enum bitpos="0" extends="VkSubpassDescriptionFlagBits" name="VK_SUBPASS_DESCRIPTION_PER_VIEW_ATTRIBUTES_BIT_NVX"/>
+                <enum bitpos="1" extends="VkSubpassDescriptionFlagBits" name="VK_SUBPASS_DESCRIPTION_PER_VIEW_POSITION_X_ONLY_BIT_NVX"/>
+                <type name="VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_viewport_swizzle" number="99" type="device" author="NV" contact="Piers Daniell @pdaniell" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_NV_VIEWPORT_SWIZZLE_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_viewport_swizzle&quot;"        name="VK_NV_VIEWPORT_SWIZZLE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV"/>
+                <type name="VkViewportSwizzleNV"/>
+                <type name="VkViewportCoordinateSwizzleNV"/>
+                <type name="VkPipelineViewportSwizzleStateCreateInfoNV"/>
+                <type name="VkPipelineViewportSwizzleStateCreateFlagsNV"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_discard_rectangles" number="100" type="device" requires="VK_KHR_get_physical_device_properties2" author="NV" contact="Piers Daniell @pdaniell" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_EXT_DISCARD_RECTANGLES_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_discard_rectangles&quot;"     name="VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT"/>
+                <enum offset="0" extends="VkDynamicState"               name="VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT"/>
+                <type name="VkPhysicalDeviceDiscardRectanglePropertiesEXT"/>
+                <type name="VkPipelineDiscardRectangleStateCreateInfoEXT"/>
+                <type name="VkPipelineDiscardRectangleStateCreateFlagsEXT"/>
+                <type name="VkDiscardRectangleModeEXT"/>
+                <command name="vkCmdSetDiscardRectangleEXT"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_101" number="101" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_NV_EXTENSION_101_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_101&quot;"           name="VK_NV_EXTENSION_101_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_102" number="102" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_NV_EXTENSION_102_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_102&quot;"           name="VK_NV_EXTENSION_102_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_103" number="103" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_NV_EXTENSION_103_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_103&quot;"           name="VK_NV_EXTENSION_103_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_104" number="104" author="NV" contact="Mathias Schott @mschott" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_NV_EXTENSION_104_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_104&quot;"           name="VK_NV_EXTENSION_104_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_swapchain_colorspace" number="105" type="instance" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtneygo" requires="VK_KHR_surface" supported="vulkan">
+            <require>
+                <enum value="3"                                         name="VK_EXT_SWAPCHAIN_COLOR_SPACE_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_swapchain_colorspace&quot;"   name="VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME"/>
+                <enum offset="1" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT"/>
+                <enum offset="2" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT"/>
+                <enum offset="3" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_DCI_P3_LINEAR_EXT"/>
+                <enum offset="4" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT"/>
+                <enum offset="5" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_BT709_LINEAR_EXT"/>
+                <enum offset="6" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_BT709_NONLINEAR_EXT"/>
+                <enum offset="7" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_BT2020_LINEAR_EXT"/>
+                <enum offset="8" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_HDR10_ST2084_EXT"/>
+                <enum offset="9" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_DOLBYVISION_EXT"/>
+                <enum offset="10" extends="VkColorSpaceKHR"             name="VK_COLOR_SPACE_HDR10_HLG_EXT"/>
+                <enum offset="11" extends="VkColorSpaceKHR"             name="VK_COLOR_SPACE_ADOBERGB_LINEAR_EXT"/>
+                <enum offset="12" extends="VkColorSpaceKHR"             name="VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT"/>
+                <enum offset="13" extends="VkColorSpaceKHR"             name="VK_COLOR_SPACE_PASS_THROUGH_EXT"/>
+                <enum offset="14" extends="VkColorSpaceKHR"             name="VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_hdr_metadata" number="106" type="device" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtneygo" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_EXT_HDR_METADATA_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_hdr_metadata&quot;"           name="VK_EXT_HDR_METADATA_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_HDR_METADATA_EXT"/>
+                <type name="VkHdrMetadataEXT"/>
+                <type name="VkXYColorEXT"/>
+                <command name="vkSetHdrMetadataEXT"/>
+            </require>
+        </extension>
+        <extension name="VK_IMG_extension_107" number="107" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_IMG_EXTENSION_107_SPEC_VERSION"/>
+                <enum value="&quot;VK_IMG_extension_107&quot;"          name="VK_IMG_EXTENSION_107_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_IMG_extension_108" number="108" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_IMG_EXTENSION_108_SPEC_VERSION"/>
+                <enum value="&quot;VK_IMG_extension_108&quot;"          name="VK_IMG_EXTENSION_108_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_IMG_extension_109" number="109" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_IMG_EXTENSION_109_SPEC_VERSION"/>
+                <enum value="&quot;VK_IMG_extension_109&quot;"          name="VK_IMG_EXTENSION_109_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_IMG_extension_110" number="110" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_IMG_EXTENSION_110_SPEC_VERSION"/>
+                <enum value="&quot;VK_IMG_extension_110&quot;"          name="VK_IMG_EXTENSION_110_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_IMG_extension_111" number="111" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_IMG_EXTENSION_111_SPEC_VERSION"/>
+                <enum value="&quot;VK_IMG_extension_111&quot;"          name="VK_IMG_EXTENSION_111_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_shared_presentable_image" number="112" type="device" requires="VK_KHR_surface,VK_KHR_swapchain,VK_KHR_get_physical_device_properties2,VK_KHR_get_surface_capabilities2" author="KHR" contact="Alon Or-bach @alonorbach" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_KHR_SHARED_PRESENTABLE_IMAGE_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_shared_presentable_image&quot;"   name="VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR"/>
+                <enum offset="0" extends="VkPresentModeKHR"             name="VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR"/>
+                <enum offset="1" extends="VkPresentModeKHR"             name="VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR"/>
+                <enum offset="0" extends="VkImageLayout"                name="VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR"/>
+                <type name="VkSharedPresentSurfaceCapabilitiesKHR"/>
+                <command name="vkGetSwapchainStatusKHR"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_external_fence_capabilities" number="113" type="instance" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="Jesse Hall @jessehall" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_KHR_EXTERNAL_FENCE_CAPABILITIES_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_external_fence_capabilities&quot;" name="VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES_KHR"/>
+                <enum name="VK_LUID_SIZE_KHR"/>
+                <type name="VkExternalFenceHandleTypeFlagsKHR"/>
+                <type name="VkExternalFenceHandleTypeFlagBitsKHR"/>
+                <type name="VkExternalFenceFeatureFlagsKHR"/>
+                <type name="VkExternalFenceFeatureFlagBitsKHR"/>
+                <type name="VkPhysicalDeviceExternalFenceInfoKHR"/>
+                <type name="VkExternalFencePropertiesKHR"/>
+                <type name="VkPhysicalDeviceIDPropertiesKHR"/>
+                <command name="vkGetPhysicalDeviceExternalFencePropertiesKHR"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_external_fence" number="114" type="device" requires="VK_KHR_external_fence_capabilities" author="KHR" contact="Jesse Hall @jessehall" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_KHR_EXTERNAL_FENCE_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_external_fence&quot;"         name="VK_KHR_EXTERNAL_FENCE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO_KHR"/>
+                <type name="VkFenceImportFlagsKHR"/>
+                <type name="VkFenceImportFlagBitsKHR"/>
+                <type name="VkExportFenceCreateInfoKHR"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_external_fence_win32" number="115" type="device" requires="VK_KHR_external_fence" author="KHR" contact="Jesse Hall @jessehall" protect="VK_USE_PLATFORM_WIN32_KHR" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_KHR_EXTERNAL_FENCE_WIN32_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_external_fence_win32&quot;"   name="VK_KHR_EXTERNAL_FENCE_WIN32_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMPORT_FENCE_WIN32_HANDLE_INFO_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXPORT_FENCE_WIN32_HANDLE_INFO_KHR"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_FENCE_GET_WIN32_HANDLE_INFO_KHR"/>
+                <type name="VkImportFenceWin32HandleInfoKHR"/>
+                <type name="VkExportFenceWin32HandleInfoKHR"/>
+                <type name="VkFenceGetWin32HandleInfoKHR"/>
+                <command name="vkImportFenceWin32HandleKHR"/>
+                <command name="vkGetFenceWin32HandleKHR"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_external_fence_fd" number="116" type="device" requires="VK_KHR_external_fence" author="KHR" contact="Jesse Hall @jessehall" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_KHR_EXTERNAL_FENCE_FD_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_external_fence_fd&quot;"      name="VK_KHR_EXTERNAL_FENCE_FD_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMPORT_FENCE_FD_INFO_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR"/>
+                <type name="VkImportFenceFdInfoKHR"/>
+                <type name="VkFenceGetFdInfoKHR"/>
+                <command name="vkImportFenceFdKHR"/>
+                <command name="vkGetFenceFdKHR"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_117" number="117" author="KHR" contact="Kenneth Benzie @kbenzie" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_117_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_117&quot;"          name="VK_KHR_EXTENSION_117_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_118" number="118" author="KHR" contact="Michael Worcester @michaelworcester" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_118_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_118&quot;"          name="VK_KHR_EXTENSION_118_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_119" number="119" author="KHR" contact="Michael Worcester @michaelworcester" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_119_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_119&quot;"          name="VK_KHR_EXTENSION_119_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_get_surface_capabilities2" number="120" type="instance" requires="VK_KHR_surface" author="KHR" contact="James Jones @cubanismo" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_KHR_GET_SURFACE_CAPABILITIES_2_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_get_surface_capabilities2&quot;" name="VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR"/>
+                <type name="VkPhysicalDeviceSurfaceInfo2KHR"/>
+                <type name="VkSurfaceCapabilities2KHR"/>
+                <type name="VkSurfaceFormat2KHR"/>
+                <command name="vkGetPhysicalDeviceSurfaceCapabilities2KHR"/>
+                <command name="vkGetPhysicalDeviceSurfaceFormats2KHR"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_variable_pointers" number="121" type="device" author="KHR" contact="Jesse Hall @jessehall" requires="VK_KHR_get_physical_device_properties2,VK_KHR_storage_buffer_storage_class" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_KHR_VARIABLE_POINTERS_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_variable_pointers&quot;"      name="VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES_KHR"/>
+                <type name="VkPhysicalDeviceVariablePointerFeaturesKHR"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_122" number="122" author="KHR" contact="James Jones @cubanismo" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_122_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_122&quot;"          name="VK_KHR_EXTENSION_122_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_MVK_ios_surface" number="123" type="instance" requires="VK_KHR_surface" protect="VK_USE_PLATFORM_IOS_MVK" supported="vulkan" author="MVK" contact="Bill Hollings @billhollings">
+            <require>
+                <enum value="2"                                         name="VK_MVK_IOS_SURFACE_SPEC_VERSION"/>
+                <enum value="&quot;VK_MVK_ios_surface&quot;"            name="VK_MVK_IOS_SURFACE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK"/>
+                <type name="VkIOSSurfaceCreateFlagsMVK"/>
+                <type name="VkIOSSurfaceCreateInfoMVK"/>
+                <command name="vkCreateIOSSurfaceMVK"/>
+            </require>
+        </extension>
+        <extension name="VK_MVK_macos_surface" number="124" type="instance" requires="VK_KHR_surface" protect="VK_USE_PLATFORM_MACOS_MVK" supported="vulkan" author="MVK" contact="Bill Hollings @billhollings">
+            <require>
+                <enum value="2"                                         name="VK_MVK_MACOS_SURFACE_SPEC_VERSION"/>
+                <enum value="&quot;VK_MVK_macos_surface&quot;"          name="VK_MVK_MACOS_SURFACE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK"/>
+                <type name="VkMacOSSurfaceCreateFlagsMVK"/>
+                <type name="VkMacOSSurfaceCreateInfoMVK"/>
+                <command name="vkCreateMacOSSurfaceMVK"/>
+            </require>
+        </extension>
+        <extension name="VK_MVK_moltenvk" number="125" type="instance" author="MVK" contact="Bill Hollings @billhollings" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_MVK_MOLTENVK_SPEC_VERSION"/>
+                <enum value="&quot;VK_MVK_moltenvk&quot;"               name="VK_MVK_MOLTENVK_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_MESA_extension_126" number="126" author="MESA" contact="Chad Versace @chadversary" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_MESA_EXTENSION_126_SPEC_VERSION"/>
+                <enum value="&quot;VK_MESA_extension_126&quot;"         name="VK_MESA_EXTENSION_126_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_MESA_extension_127" number="127" author="MESA" contact="Chad Versace @chadversary" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_MESA_EXTENSION_127_SPEC_VERSION"/>
+                <enum value="&quot;VK_MESA_extension_127&quot;"         name="VK_MESA_EXTENSION_127_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_dedicated_allocation" number="128" type="device" author="KHR" contact="James Jones @cubanismo" supported="vulkan">
+            <require>
+                <enum value="3"                                         name="VK_KHR_DEDICATED_ALLOCATION_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_dedicated_allocation&quot;"   name="VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR"/>
+                <type name="VkMemoryDedicatedRequirementsKHR"/>
+                <type name="VkMemoryDedicatedAllocateInfoKHR"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_129" number="129" author="LUNARG" contact="Mark Young @MarkY_LunarG" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_129_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_129&quot;"          name="VK_KHR_EXTENSION_129_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_130" number="130" author="KHR" contact="Jesse Hall @jessehall" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_130_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_130&quot;"          name="VK_KHR_EXTENSION_130_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_sampler_filter_minmax" number="131" type="device" author="NV" requires="VK_KHR_get_physical_device_properties2" contact="Jeff Bolz @jbolz" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_EXT_SAMPLER_FILTER_MINMAX_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_sampler_filter_minmax&quot;"  name="VK_EXT_SAMPLER_FILTER_MINMAX_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES_EXT"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT"/>
+                <enum bitpos="16" extends="VkFormatFeatureFlagBits"     name="VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT" comment="Format can be used with min/max reduction filtering"/>
+                <type name="VkSamplerReductionModeEXT"/>
+                <type name="VkSamplerReductionModeCreateInfoEXT"/>
+                <type name="VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_storage_buffer_storage_class" number="132" type="device" author="KHR" contact="Alexander Galazin @debater" supported="vulkan">
+            <require>
+                <enum value="1"                                                 name="VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_storage_buffer_storage_class&quot;"   name="VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_gpu_shader_int16" number="133" type="device" author="AMD" contact="quentin.lin@amd.com" supported="vulkan">
+            <require>
+                <enum value="1"                                    name="VK_AMD_GPU_SHADER_INT16_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_gpu_shader_int16&quot;"  name="VK_AMD_GPU_SHADER_INT16_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_134" number="134" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_134_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_134&quot;"           name="VK_AMD_EXTENSION_134_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_135" number="135" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_135_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_135&quot;"           name="VK_AMD_EXTENSION_135_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_136" number="136" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_136_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_136&quot;"           name="VK_AMD_EXTENSION_136_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_mixed_attachment_samples" number="137" author="AMD" contact="Matthaeus G. Chajdas @anteru" supported="vulkan">
+            <require>
+                <enum value="1"                                          name="VK_AMD_MIXED_ATTACHMENT_SAMPLES_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_mixed_attachment_samples&quot;" name="VK_AMD_MIXED_ATTACHMENT_SAMPLES_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_138" number="138" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_138_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_138&quot;"           name="VK_AMD_EXTENSION_138_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_139" number="139" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_139_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_139&quot;"           name="VK_AMD_EXTENSION_139_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_140" number="140" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_140_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_140&quot;"           name="VK_AMD_EXTENSION_140_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_141" number="141" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_141_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_141&quot;"           name="VK_AMD_EXTENSION_141_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_142" number="142" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_142_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_142&quot;"           name="VK_AMD_EXTENSION_142_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_143" number="143" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_143_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_143&quot;"           name="VK_AMD_EXTENSION_143_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_144" number="144" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_144_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_144&quot;"           name="VK_AMD_EXTENSION_144_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_relaxed_block_layout" number="145" type="device" author="KHR" contact="John Kessenich @johnk" supported="vulkan">
+            <require>
+                <enum value="1"                                          name="VK_KHR_RELAXED_BLOCK_LAYOUT_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_relaxed_block_layout&quot;"    name="VK_KHR_RELAXED_BLOCK_LAYOUT_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_146" number="146" author="KHR" contact="Bill Licea-Kane @billl" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_KHR_extension_146_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_146&quot;"    name="VK_KHR_extension_146_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_get_memory_requirements2" number="147" type="device" author="KHR" contact="Jason Ekstrand @jekstrand" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_KHR_GET_MEMORY_REQUIREMENTS_2_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_get_memory_requirements2&quot;" name="VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2_KHR"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMAGE_SPARSE_MEMORY_REQUIREMENTS_INFO_2_KHR"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR"/>
+                <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2_KHR"/>
+                <type name="VkBufferMemoryRequirementsInfo2KHR"/>
+                <type name="VkImageMemoryRequirementsInfo2KHR"/>
+                <type name="VkImageSparseMemoryRequirementsInfo2KHR"/>
+                <type name="VkMemoryRequirements2KHR"/>
+                <type name="VkSparseImageMemoryRequirements2KHR"/>
+                <command name="vkGetImageMemoryRequirements2KHR"/>
+                <command name="vkGetBufferMemoryRequirements2KHR"/>
+                <command name="vkGetImageSparseMemoryRequirements2KHR"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_148" number="148" author="EXT" contact="Jason Ekstrand @jekstrand" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_KHR_EXTENSION_148_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_148&quot;"           name="VK_KHR_EXTENSION_148_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_blend_operation_advanced" number="149" type="device" author="NV" contact="Jeff Bolz @jbolz" supported="vulkan">
+            <require>
+                <enum value="2"                                          name="VK_EXT_BLEND_OPERATION_ADVANCED_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_blend_operation_advanced&quot;" name="VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"               name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT"/>
+                <enum offset="1" extends="VkStructureType"               name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT"/>
+                <enum offset="2" extends="VkStructureType"               name="VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT"/>
+                <type name="VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"/>
+                <type name="VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"/>
+                <type name="VkPipelineColorBlendAdvancedStateCreateInfoEXT"/>
+                <type name="VkBlendOverlapEXT"/>
+                <enum offset="0" extends="VkBlendOp"                     name="VK_BLEND_OP_ZERO_EXT"/>
+                <enum offset="1" extends="VkBlendOp"                     name="VK_BLEND_OP_SRC_EXT"/>
+                <enum offset="2" extends="VkBlendOp"                     name="VK_BLEND_OP_DST_EXT"/>
+                <enum offset="3" extends="VkBlendOp"                     name="VK_BLEND_OP_SRC_OVER_EXT"/>
+                <enum offset="4" extends="VkBlendOp"                     name="VK_BLEND_OP_DST_OVER_EXT"/>
+                <enum offset="5" extends="VkBlendOp"                     name="VK_BLEND_OP_SRC_IN_EXT"/>
+                <enum offset="6" extends="VkBlendOp"                     name="VK_BLEND_OP_DST_IN_EXT"/>
+                <enum offset="7" extends="VkBlendOp"                     name="VK_BLEND_OP_SRC_OUT_EXT"/>
+                <enum offset="8" extends="VkBlendOp"                     name="VK_BLEND_OP_DST_OUT_EXT"/>
+                <enum offset="9" extends="VkBlendOp"                     name="VK_BLEND_OP_SRC_ATOP_EXT"/>
+                <enum offset="10" extends="VkBlendOp"                    name="VK_BLEND_OP_DST_ATOP_EXT"/>
+                <enum offset="11" extends="VkBlendOp"                    name="VK_BLEND_OP_XOR_EXT"/>
+                <enum offset="12" extends="VkBlendOp"                    name="VK_BLEND_OP_MULTIPLY_EXT"/>
+                <enum offset="13" extends="VkBlendOp"                    name="VK_BLEND_OP_SCREEN_EXT"/>
+                <enum offset="14" extends="VkBlendOp"                    name="VK_BLEND_OP_OVERLAY_EXT"/>
+                <enum offset="15" extends="VkBlendOp"                    name="VK_BLEND_OP_DARKEN_EXT"/>
+                <enum offset="16" extends="VkBlendOp"                    name="VK_BLEND_OP_LIGHTEN_EXT"/>
+                <enum offset="17" extends="VkBlendOp"                    name="VK_BLEND_OP_COLORDODGE_EXT"/>
+                <enum offset="18" extends="VkBlendOp"                    name="VK_BLEND_OP_COLORBURN_EXT"/>
+                <enum offset="19" extends="VkBlendOp"                    name="VK_BLEND_OP_HARDLIGHT_EXT"/>
+                <enum offset="20" extends="VkBlendOp"                    name="VK_BLEND_OP_SOFTLIGHT_EXT"/>
+                <enum offset="21" extends="VkBlendOp"                    name="VK_BLEND_OP_DIFFERENCE_EXT"/>
+                <enum offset="22" extends="VkBlendOp"                    name="VK_BLEND_OP_EXCLUSION_EXT"/>
+                <enum offset="23" extends="VkBlendOp"                    name="VK_BLEND_OP_INVERT_EXT"/>
+                <enum offset="24" extends="VkBlendOp"                    name="VK_BLEND_OP_INVERT_RGB_EXT"/>
+                <enum offset="25" extends="VkBlendOp"                    name="VK_BLEND_OP_LINEARDODGE_EXT"/>
+                <enum offset="26" extends="VkBlendOp"                    name="VK_BLEND_OP_LINEARBURN_EXT"/>
+                <enum offset="27" extends="VkBlendOp"                    name="VK_BLEND_OP_VIVIDLIGHT_EXT"/>
+                <enum offset="28" extends="VkBlendOp"                    name="VK_BLEND_OP_LINEARLIGHT_EXT"/>
+                <enum offset="29" extends="VkBlendOp"                    name="VK_BLEND_OP_PINLIGHT_EXT"/>
+                <enum offset="30" extends="VkBlendOp"                    name="VK_BLEND_OP_HARDMIX_EXT"/>
+                <enum offset="31" extends="VkBlendOp"                    name="VK_BLEND_OP_HSL_HUE_EXT"/>
+                <enum offset="32" extends="VkBlendOp"                    name="VK_BLEND_OP_HSL_SATURATION_EXT"/>
+                <enum offset="33" extends="VkBlendOp"                    name="VK_BLEND_OP_HSL_COLOR_EXT"/>
+                <enum offset="34" extends="VkBlendOp"                    name="VK_BLEND_OP_HSL_LUMINOSITY_EXT"/>
+                <enum offset="35" extends="VkBlendOp"                    name="VK_BLEND_OP_PLUS_EXT"/>
+                <enum offset="36" extends="VkBlendOp"                    name="VK_BLEND_OP_PLUS_CLAMPED_EXT"/>
+                <enum offset="37" extends="VkBlendOp"                    name="VK_BLEND_OP_PLUS_CLAMPED_ALPHA_EXT"/>
+                <enum offset="38" extends="VkBlendOp"                    name="VK_BLEND_OP_PLUS_DARKER_EXT"/>
+                <enum offset="39" extends="VkBlendOp"                    name="VK_BLEND_OP_MINUS_EXT"/>
+                <enum offset="40" extends="VkBlendOp"                    name="VK_BLEND_OP_MINUS_CLAMPED_EXT"/>
+                <enum offset="41" extends="VkBlendOp"                    name="VK_BLEND_OP_CONTRAST_EXT"/>
+                <enum offset="42" extends="VkBlendOp"                    name="VK_BLEND_OP_INVERT_OVG_EXT"/>
+                <enum offset="43" extends="VkBlendOp"                    name="VK_BLEND_OP_RED_EXT"/>
+                <enum offset="44" extends="VkBlendOp"                    name="VK_BLEND_OP_GREEN_EXT"/>
+                <enum offset="45" extends="VkBlendOp"                    name="VK_BLEND_OP_BLUE_EXT"/>
+                <enum bitpos="19" extends="VkAccessFlagBits"             name="VK_ACCESS_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_fragment_coverage_to_color" number="150" type="device" author="NV" contact="Jeff Bolz @jbolz" supported="vulkan">
+            <require>
+                <enum value="1"                                          name="VK_NV_FRAGMENT_COVERAGE_TO_COLOR_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_fragment_coverage_to_color&quot;" name="VK_NV_FRAGMENT_COVERAGE_TO_COLOR_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"               name="VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_TO_COLOR_STATE_CREATE_INFO_NV"/>
+                <type name="VkPipelineCoverageToColorStateCreateFlagsNV"/>
+                <type name="VkPipelineCoverageToColorStateCreateInfoNV"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_151" number="151" author="NV" contact="Jeff Bolz @jbolz" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_NV_EXTENSION_151_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_151&quot;"            name="VK_NV_EXTENSION_151_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_152" number="152" author="NV" contact="Jeff Bolz @jbolz" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_NV_EXTENSION_152_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_152&quot;"            name="VK_NV_EXTENSION_152_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_framebuffer_mixed_samples" number="153" type="device" author="NV" contact="Jeff Bolz @jbolz" supported="vulkan">
+            <require>
+                <enum value="1"                                          name="VK_NV_FRAMEBUFFER_MIXED_SAMPLES_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_framebuffer_mixed_samples&quot;" name="VK_NV_FRAMEBUFFER_MIXED_SAMPLES_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"               name="VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV"/>
+                <type name="VkPipelineCoverageModulationStateCreateInfoNV"/>
+                <type name="VkPipelineCoverageModulationStateCreateFlagsNV"/>
+                <type name="VkCoverageModulationModeNV"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_fill_rectangle" number="154" type="device" author="NV" contact="Jeff Bolz @jbolz" supported="vulkan">
+            <require>
+                <enum value="1"                                          name="VK_NV_FILL_RECTANGLE_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_fill_rectangle&quot;"           name="VK_NV_FILL_RECTANGLE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkPolygonMode"                 name="VK_POLYGON_MODE_FILL_RECTANGLE_NV"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_155" number="155" author="NV" contact="Jeff Bolz @jbolz" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_NV_EXTENSION_155_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_155&quot;"            name="VK_NV_EXTENSION_155_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_post_depth_coverage" number="156" type="device" author="NV" contact="Daniel Koch @dgkoch" supported="vulkan">
+            <require>
+                <enum value="1"                                          name="VK_EXT_POST_DEPTH_COVERAGE_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_post_depth_coverage&quot;"     name="VK_EXT_POST_DEPTH_COVERAGE_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_157" number="157" author="KHR" contact="Andrew Garrard @fluppeteer" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_KHR_EXTENSION_157_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_157&quot;"           name="VK_KHR_EXTENSION_157_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_158" number="158" author="KHR" contact="Tobias Hector @tobias" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_KHR_EXTENSION_158_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_158&quot;"           name="VK_KHR_EXTENSION_158_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_159" number="159" author="EXT" contact="Chad Versace @chadversary" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_EXT_EXTENSION_159_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_159&quot;"           name="VK_EXT_EXTENSION_159_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_160" number="160" author="EXT" contact="Mark Young @MarkY_LunarG" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_EXT_EXTENSION_160_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_160&quot;"           name="VK_EXT_EXTENSION_160_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_161" number="161" author="GOOGLE" contact="Cort Stratton @cdwfs" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_EXT_EXTENSION_161_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_161&quot;"           name="VK_EXT_EXTENSION_161_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_162" number="162" author="NV" contact="Jeff Bolz @jbolz" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_EXT_EXTENSION_162_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_162&quot;"           name="VK_EXT_EXTENSION_162_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_shader_viewport_index_layer" number="163" type="device" author="NV" contact="Daniel Koch @dgkoch" supported="vulkan">
+            <require>
+                <enum value="1"                                          name="VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_shader_viewport_index_layer&quot;"  name="VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_164" number="164" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_EXT_EXTENSION_164_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_164&quot;"            name="VK_EXT_EXTENSION_164_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_165" number="165" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_EXT_EXTENSION_165_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_165&quot;"            name="VK_EXT_EXTENSION_165_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_166" number="166" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_EXT_EXTENSION_166_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_166&quot;"            name="VK_EXT_EXTENSION_166_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_167" number="167" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_EXT_EXTENSION_167_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_167&quot;"            name="VK_EXT_EXTENSION_167_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_168" number="168" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_EXT_EXTENSION_168_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_168&quot;"            name="VK_EXT_EXTENSION_168_EXTENSION_NAME"/>
+            </require>
+        </extension>
     </extensions>
 </registry>

--- a/src/vk/Generated/Commands.gen.cs
+++ b/src/vk/Generated/Commands.gen.cs
@@ -7,6 +7,70 @@ namespace Vulkan
 {
     public static unsafe partial class VulkanNative
     {
+        private static IntPtr vkAcquireNextImage2KHX_ptr;
+        ///<remarks>Success codes:VK_SUCCESS, VK_TIMEOUT, VK_NOT_READY, VK_SUBOPTIMAL_KHR. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkAcquireNextImage2KHX(VkDevice device, VkAcquireNextImageInfoKHX* pAcquireInfo, uint* pImageIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_TIMEOUT, VK_NOT_READY, VK_SUBOPTIMAL_KHR. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkAcquireNextImage2KHX(VkDevice device, VkAcquireNextImageInfoKHX* pAcquireInfo, ref uint pImageIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_TIMEOUT, VK_NOT_READY, VK_SUBOPTIMAL_KHR. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkAcquireNextImage2KHX(VkDevice device, VkAcquireNextImageInfoKHX* pAcquireInfo, IntPtr pImageIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_TIMEOUT, VK_NOT_READY, VK_SUBOPTIMAL_KHR. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkAcquireNextImage2KHX(VkDevice device, ref VkAcquireNextImageInfoKHX pAcquireInfo, uint* pImageIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_TIMEOUT, VK_NOT_READY, VK_SUBOPTIMAL_KHR. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkAcquireNextImage2KHX(VkDevice device, ref VkAcquireNextImageInfoKHX pAcquireInfo, ref uint pImageIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_TIMEOUT, VK_NOT_READY, VK_SUBOPTIMAL_KHR. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkAcquireNextImage2KHX(VkDevice device, ref VkAcquireNextImageInfoKHX pAcquireInfo, IntPtr pImageIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_TIMEOUT, VK_NOT_READY, VK_SUBOPTIMAL_KHR. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkAcquireNextImage2KHX(VkDevice device, IntPtr pAcquireInfo, uint* pImageIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_TIMEOUT, VK_NOT_READY, VK_SUBOPTIMAL_KHR. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkAcquireNextImage2KHX(VkDevice device, IntPtr pAcquireInfo, ref uint pImageIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_TIMEOUT, VK_NOT_READY, VK_SUBOPTIMAL_KHR. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkAcquireNextImage2KHX(VkDevice device, IntPtr pAcquireInfo, IntPtr pImageIndex)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkAcquireNextImageKHR_ptr;
         ///<remarks>Success codes:VK_SUCCESS, VK_TIMEOUT, VK_NOT_READY, VK_SUBOPTIMAL_KHR. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
         [Generator.CalliRewrite]
@@ -25,6 +89,28 @@ namespace Vulkan
         ///<remarks>Success codes:VK_SUCCESS, VK_TIMEOUT, VK_NOT_READY, VK_SUBOPTIMAL_KHR. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, ulong timeout, VkSemaphore semaphore, VkFence fence, IntPtr pImageIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkAcquireXlibDisplayEXT_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_INITIALIZATION_FAILED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkAcquireXlibDisplayEXT(VkPhysicalDevice physicalDevice, Xlib.Display* dpy, VkDisplayKHR display)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_INITIALIZATION_FAILED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkAcquireXlibDisplayEXT(VkPhysicalDevice physicalDevice, ref Xlib.Display dpy, VkDisplayKHR display)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_INITIALIZATION_FAILED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkAcquireXlibDisplayEXT(VkPhysicalDevice physicalDevice, IntPtr dpy, VkDisplayKHR display)
         {
             throw new NotImplementedException();
         }
@@ -73,42 +159,42 @@ namespace Vulkan
         }
 
         private static IntPtr vkAllocateDescriptorSets_ptr;
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FRAGMENTED_POOL</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FRAGMENTED_POOL, VK_ERROR_OUT_OF_POOL_MEMORY_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateDescriptorSets(VkDevice device, VkDescriptorSetAllocateInfo* pAllocateInfo, VkDescriptorSet* pDescriptorSets)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FRAGMENTED_POOL</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FRAGMENTED_POOL, VK_ERROR_OUT_OF_POOL_MEMORY_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateDescriptorSets(VkDevice device, VkDescriptorSetAllocateInfo* pAllocateInfo, out VkDescriptorSet pDescriptorSets)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FRAGMENTED_POOL</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FRAGMENTED_POOL, VK_ERROR_OUT_OF_POOL_MEMORY_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateDescriptorSets(VkDevice device, ref VkDescriptorSetAllocateInfo pAllocateInfo, VkDescriptorSet* pDescriptorSets)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FRAGMENTED_POOL</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FRAGMENTED_POOL, VK_ERROR_OUT_OF_POOL_MEMORY_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateDescriptorSets(VkDevice device, ref VkDescriptorSetAllocateInfo pAllocateInfo, out VkDescriptorSet pDescriptorSets)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FRAGMENTED_POOL</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FRAGMENTED_POOL, VK_ERROR_OUT_OF_POOL_MEMORY_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateDescriptorSets(VkDevice device, IntPtr pAllocateInfo, VkDescriptorSet* pDescriptorSets)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FRAGMENTED_POOL</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FRAGMENTED_POOL, VK_ERROR_OUT_OF_POOL_MEMORY_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateDescriptorSets(VkDevice device, IntPtr pAllocateInfo, out VkDescriptorSet pDescriptorSets)
         {
@@ -116,126 +202,126 @@ namespace Vulkan
         }
 
         private static IntPtr vkAllocateMemory_ptr;
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, VkMemoryAllocateInfo* pAllocateInfo, VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, VkMemoryAllocateInfo* pAllocateInfo, VkAllocationCallbacks* pAllocator, out VkDeviceMemory pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, VkMemoryAllocateInfo* pAllocateInfo, ref VkAllocationCallbacks pAllocator, VkDeviceMemory* pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, VkMemoryAllocateInfo* pAllocateInfo, ref VkAllocationCallbacks pAllocator, out VkDeviceMemory pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, VkMemoryAllocateInfo* pAllocateInfo, IntPtr pAllocator, VkDeviceMemory* pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, VkMemoryAllocateInfo* pAllocateInfo, IntPtr pAllocator, out VkDeviceMemory pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, ref VkMemoryAllocateInfo pAllocateInfo, VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, ref VkMemoryAllocateInfo pAllocateInfo, VkAllocationCallbacks* pAllocator, out VkDeviceMemory pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, ref VkMemoryAllocateInfo pAllocateInfo, ref VkAllocationCallbacks pAllocator, VkDeviceMemory* pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, ref VkMemoryAllocateInfo pAllocateInfo, ref VkAllocationCallbacks pAllocator, out VkDeviceMemory pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, ref VkMemoryAllocateInfo pAllocateInfo, IntPtr pAllocator, VkDeviceMemory* pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, ref VkMemoryAllocateInfo pAllocateInfo, IntPtr pAllocator, out VkDeviceMemory pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, IntPtr pAllocateInfo, VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, IntPtr pAllocateInfo, VkAllocationCallbacks* pAllocator, out VkDeviceMemory pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, IntPtr pAllocateInfo, ref VkAllocationCallbacks pAllocator, VkDeviceMemory* pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, IntPtr pAllocateInfo, ref VkAllocationCallbacks pAllocator, out VkDeviceMemory pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, IntPtr pAllocateInfo, IntPtr pAllocator, VkDeviceMemory* pMemory)
         {
             throw new NotImplementedException();
         }
 
-        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS</remarks>
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkAllocateMemory(VkDevice device, IntPtr pAllocateInfo, IntPtr pAllocator, out VkDeviceMemory pMemory)
         {
@@ -272,10 +358,68 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkBindBufferMemory2KHX_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkBindBufferMemory2KHX(VkDevice device, uint bindInfoCount, VkBindBufferMemoryInfoKHX* pBindInfos)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkBindBufferMemory2KHX(VkDevice device, uint bindInfoCount, ref VkBindBufferMemoryInfoKHX pBindInfos)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkBindBufferMemory2KHX(VkDevice device, uint bindInfoCount, IntPtr pBindInfos)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkBindBufferMemory2KHX(VkDevice device, uint bindInfoCount, VkBindBufferMemoryInfoKHX[] pBindInfos)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkBindImageMemory_ptr;
         ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, ulong memoryOffset)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkBindImageMemory2KHX_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkBindImageMemory2KHX(VkDevice device, uint bindInfoCount, VkBindImageMemoryInfoKHX* pBindInfos)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkBindImageMemory2KHX(VkDevice device, uint bindInfoCount, ref VkBindImageMemoryInfoKHX pBindInfos)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkBindImageMemory2KHX(VkDevice device, uint bindInfoCount, IntPtr pBindInfos)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkBindImageMemory2KHX(VkDevice device, uint bindInfoCount, VkBindImageMemoryInfoKHX[] pBindInfos)
         {
             throw new NotImplementedException();
         }
@@ -744,7 +888,14 @@ namespace Vulkan
 
         private static IntPtr vkCmdDispatch_ptr;
         [Generator.CalliRewrite]
-        public static unsafe void vkCmdDispatch(VkCommandBuffer commandBuffer, uint x, uint y, uint z)
+        public static unsafe void vkCmdDispatch(VkCommandBuffer commandBuffer, uint groupCountX, uint groupCountY, uint groupCountZ)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkCmdDispatchBaseKHX_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkCmdDispatchBaseKHX(VkCommandBuffer commandBuffer, uint baseGroupX, uint baseGroupY, uint baseGroupZ, uint groupCountX, uint groupCountY, uint groupCountZ)
         {
             throw new NotImplementedException();
         }
@@ -1034,6 +1185,32 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkCmdPushDescriptorSetKHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipelineLayout layout, uint set, uint descriptorWriteCount, VkWriteDescriptorSet* pDescriptorWrites)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipelineLayout layout, uint set, uint descriptorWriteCount, ref VkWriteDescriptorSet pDescriptorWrites)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipelineLayout layout, uint set, uint descriptorWriteCount, IntPtr pDescriptorWrites)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkCmdPushDescriptorSetWithTemplateKHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, VkPipelineLayout layout, uint set, void* pData)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkCmdReserveSpaceForCommandsNVX_ptr;
         [Generator.CalliRewrite]
         public static unsafe void vkCmdReserveSpaceForCommandsNVX(VkCommandBuffer commandBuffer, VkCmdReserveSpaceForCommandsInfoNVX* pReserveSpaceInfo)
@@ -1107,6 +1284,32 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkCmdSetDeviceMaskKHX_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkCmdSetDeviceMaskKHX(VkCommandBuffer commandBuffer, uint deviceMask)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkCmdSetDiscardRectangleEXT_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint firstDiscardRectangle, uint discardRectangleCount, VkRect2D* pDiscardRectangles)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint firstDiscardRectangle, uint discardRectangleCount, ref VkRect2D pDiscardRectangles)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint firstDiscardRectangle, uint discardRectangleCount, IntPtr pDiscardRectangles)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkCmdSetEvent_ptr;
         [Generator.CalliRewrite]
         public static unsafe void vkCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent @event, VkPipelineStageFlags stageMask)
@@ -1176,6 +1379,25 @@ namespace Vulkan
 
         [Generator.CalliRewrite]
         public static unsafe void vkCmdSetViewport(VkCommandBuffer commandBuffer, uint firstViewport, uint viewportCount, IntPtr pViewports)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkCmdSetViewportWScalingNV_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint firstViewport, uint viewportCount, VkViewportWScalingNV* pViewportWScalings)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint firstViewport, uint viewportCount, ref VkViewportWScalingNV pViewportWScalings)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint firstViewport, uint viewportCount, IntPtr pViewportWScalings)
         {
             throw new NotImplementedException();
         }
@@ -2739,6 +2961,133 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkCreateDescriptorUpdateTemplateKHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo, VkAllocationCallbacks* pAllocator, VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo, VkAllocationCallbacks* pAllocator, out VkDescriptorUpdateTemplateKHR pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo, ref VkAllocationCallbacks pAllocator, VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo, ref VkAllocationCallbacks pAllocator, out VkDescriptorUpdateTemplateKHR pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo, IntPtr pAllocator, VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo, IntPtr pAllocator, out VkDescriptorUpdateTemplateKHR pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, ref VkDescriptorUpdateTemplateCreateInfoKHR pCreateInfo, VkAllocationCallbacks* pAllocator, VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, ref VkDescriptorUpdateTemplateCreateInfoKHR pCreateInfo, VkAllocationCallbacks* pAllocator, out VkDescriptorUpdateTemplateKHR pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, ref VkDescriptorUpdateTemplateCreateInfoKHR pCreateInfo, ref VkAllocationCallbacks pAllocator, VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, ref VkDescriptorUpdateTemplateCreateInfoKHR pCreateInfo, ref VkAllocationCallbacks pAllocator, out VkDescriptorUpdateTemplateKHR pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, ref VkDescriptorUpdateTemplateCreateInfoKHR pCreateInfo, IntPtr pAllocator, VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, ref VkDescriptorUpdateTemplateCreateInfoKHR pCreateInfo, IntPtr pAllocator, out VkDescriptorUpdateTemplateKHR pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, IntPtr pCreateInfo, VkAllocationCallbacks* pAllocator, VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, IntPtr pCreateInfo, VkAllocationCallbacks* pAllocator, out VkDescriptorUpdateTemplateKHR pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, IntPtr pCreateInfo, ref VkAllocationCallbacks pAllocator, VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, IntPtr pCreateInfo, ref VkAllocationCallbacks pAllocator, out VkDescriptorUpdateTemplateKHR pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, IntPtr pCreateInfo, IntPtr pAllocator, VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateDescriptorUpdateTemplateKHR(VkDevice device, IntPtr pCreateInfo, IntPtr pAllocator, out VkDescriptorUpdateTemplateKHR pDescriptorUpdateTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkCreateDevice_ptr;
         ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_INITIALIZATION_FAILED, VK_ERROR_EXTENSION_NOT_PRESENT, VK_ERROR_FEATURE_NOT_PRESENT, VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_DEVICE_LOST</remarks>
         [Generator.CalliRewrite]
@@ -4174,6 +4523,260 @@ namespace Vulkan
         ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_INITIALIZATION_FAILED, VK_ERROR_LAYER_NOT_PRESENT, VK_ERROR_EXTENSION_NOT_PRESENT, VK_ERROR_INCOMPATIBLE_DRIVER</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkCreateInstance(IntPtr pCreateInfo, IntPtr pAllocator, out VkInstance pInstance)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkCreateIOSSurfaceMVK_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, VkIOSSurfaceCreateInfoMVK* pCreateInfo, VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, VkIOSSurfaceCreateInfoMVK* pCreateInfo, VkAllocationCallbacks* pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, VkIOSSurfaceCreateInfoMVK* pCreateInfo, ref VkAllocationCallbacks pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, VkIOSSurfaceCreateInfoMVK* pCreateInfo, ref VkAllocationCallbacks pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, VkIOSSurfaceCreateInfoMVK* pCreateInfo, IntPtr pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, VkIOSSurfaceCreateInfoMVK* pCreateInfo, IntPtr pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, ref VkIOSSurfaceCreateInfoMVK pCreateInfo, VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, ref VkIOSSurfaceCreateInfoMVK pCreateInfo, VkAllocationCallbacks* pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, ref VkIOSSurfaceCreateInfoMVK pCreateInfo, ref VkAllocationCallbacks pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, ref VkIOSSurfaceCreateInfoMVK pCreateInfo, ref VkAllocationCallbacks pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, ref VkIOSSurfaceCreateInfoMVK pCreateInfo, IntPtr pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, ref VkIOSSurfaceCreateInfoMVK pCreateInfo, IntPtr pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, IntPtr pCreateInfo, VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, IntPtr pCreateInfo, VkAllocationCallbacks* pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, IntPtr pCreateInfo, ref VkAllocationCallbacks pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, IntPtr pCreateInfo, ref VkAllocationCallbacks pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, IntPtr pCreateInfo, IntPtr pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateIOSSurfaceMVK(VkInstance instance, IntPtr pCreateInfo, IntPtr pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkCreateMacOSSurfaceMVK_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, VkMacOSSurfaceCreateInfoMVK* pCreateInfo, VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, VkMacOSSurfaceCreateInfoMVK* pCreateInfo, VkAllocationCallbacks* pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, VkMacOSSurfaceCreateInfoMVK* pCreateInfo, ref VkAllocationCallbacks pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, VkMacOSSurfaceCreateInfoMVK* pCreateInfo, ref VkAllocationCallbacks pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, VkMacOSSurfaceCreateInfoMVK* pCreateInfo, IntPtr pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, VkMacOSSurfaceCreateInfoMVK* pCreateInfo, IntPtr pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, ref VkMacOSSurfaceCreateInfoMVK pCreateInfo, VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, ref VkMacOSSurfaceCreateInfoMVK pCreateInfo, VkAllocationCallbacks* pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, ref VkMacOSSurfaceCreateInfoMVK pCreateInfo, ref VkAllocationCallbacks pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, ref VkMacOSSurfaceCreateInfoMVK pCreateInfo, ref VkAllocationCallbacks pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, ref VkMacOSSurfaceCreateInfoMVK pCreateInfo, IntPtr pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, ref VkMacOSSurfaceCreateInfoMVK pCreateInfo, IntPtr pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, IntPtr pCreateInfo, VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, IntPtr pCreateInfo, VkAllocationCallbacks* pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, IntPtr pCreateInfo, ref VkAllocationCallbacks pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, IntPtr pCreateInfo, ref VkAllocationCallbacks pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, IntPtr pCreateInfo, IntPtr pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateMacOSSurfaceMVK(VkInstance instance, IntPtr pCreateInfo, IntPtr pAllocator, out VkSurfaceKHR pSurface)
         {
             throw new NotImplementedException();
         }
@@ -5617,6 +6220,133 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkCreateViSurfaceNN_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, VkViSurfaceCreateInfoNN* pCreateInfo, VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, VkViSurfaceCreateInfoNN* pCreateInfo, VkAllocationCallbacks* pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, VkViSurfaceCreateInfoNN* pCreateInfo, ref VkAllocationCallbacks pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, VkViSurfaceCreateInfoNN* pCreateInfo, ref VkAllocationCallbacks pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, VkViSurfaceCreateInfoNN* pCreateInfo, IntPtr pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, VkViSurfaceCreateInfoNN* pCreateInfo, IntPtr pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, ref VkViSurfaceCreateInfoNN pCreateInfo, VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, ref VkViSurfaceCreateInfoNN pCreateInfo, VkAllocationCallbacks* pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, ref VkViSurfaceCreateInfoNN pCreateInfo, ref VkAllocationCallbacks pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, ref VkViSurfaceCreateInfoNN pCreateInfo, ref VkAllocationCallbacks pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, ref VkViSurfaceCreateInfoNN pCreateInfo, IntPtr pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, ref VkViSurfaceCreateInfoNN pCreateInfo, IntPtr pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, IntPtr pCreateInfo, VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, IntPtr pCreateInfo, VkAllocationCallbacks* pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, IntPtr pCreateInfo, ref VkAllocationCallbacks pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, IntPtr pCreateInfo, ref VkAllocationCallbacks pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, IntPtr pCreateInfo, IntPtr pAllocator, VkSurfaceKHR* pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_NATIVE_WINDOW_IN_USE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkCreateViSurfaceNN(VkInstance instance, IntPtr pCreateInfo, IntPtr pAllocator, out VkSurfaceKHR pSurface)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkCreateWaylandSurfaceKHR_ptr;
         ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
         [Generator.CalliRewrite]
@@ -6308,6 +7038,25 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkDestroyDescriptorUpdateTemplateKHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkDestroyDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, VkAllocationCallbacks* pAllocator)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkDestroyDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, ref VkAllocationCallbacks pAllocator)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkDestroyDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, IntPtr pAllocator)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkDestroyDevice_ptr;
         [Generator.CalliRewrite]
         public static unsafe void vkDestroyDevice(VkDevice device, VkAllocationCallbacks* pAllocator)
@@ -6673,6 +7422,28 @@ namespace Vulkan
         ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_DEVICE_LOST</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkDeviceWaitIdle(VkDevice device)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkDisplayPowerControlEXT_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkDisplayPowerControlEXT(VkDevice device, VkDisplayKHR display, VkDisplayPowerInfoEXT* pDisplayPowerInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkDisplayPowerControlEXT(VkDevice device, VkDisplayKHR display, ref VkDisplayPowerInfoEXT pDisplayPowerInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkDisplayPowerControlEXT(VkDevice device, VkDisplayKHR display, IntPtr pDisplayPowerInfo)
         {
             throw new NotImplementedException();
         }
@@ -7067,6 +7838,70 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkEnumeratePhysicalDeviceGroupsKHX_ptr;
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_INITIALIZATION_FAILED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkEnumeratePhysicalDeviceGroupsKHX(VkInstance instance, uint* pPhysicalDeviceGroupCount, VkPhysicalDeviceGroupPropertiesKHX* pPhysicalDeviceGroupProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_INITIALIZATION_FAILED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkEnumeratePhysicalDeviceGroupsKHX(VkInstance instance, uint* pPhysicalDeviceGroupCount, ref VkPhysicalDeviceGroupPropertiesKHX pPhysicalDeviceGroupProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_INITIALIZATION_FAILED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkEnumeratePhysicalDeviceGroupsKHX(VkInstance instance, uint* pPhysicalDeviceGroupCount, IntPtr pPhysicalDeviceGroupProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_INITIALIZATION_FAILED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkEnumeratePhysicalDeviceGroupsKHX(VkInstance instance, ref uint pPhysicalDeviceGroupCount, VkPhysicalDeviceGroupPropertiesKHX* pPhysicalDeviceGroupProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_INITIALIZATION_FAILED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkEnumeratePhysicalDeviceGroupsKHX(VkInstance instance, ref uint pPhysicalDeviceGroupCount, ref VkPhysicalDeviceGroupPropertiesKHX pPhysicalDeviceGroupProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_INITIALIZATION_FAILED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkEnumeratePhysicalDeviceGroupsKHX(VkInstance instance, ref uint pPhysicalDeviceGroupCount, IntPtr pPhysicalDeviceGroupProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_INITIALIZATION_FAILED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkEnumeratePhysicalDeviceGroupsKHX(VkInstance instance, IntPtr pPhysicalDeviceGroupCount, VkPhysicalDeviceGroupPropertiesKHX* pPhysicalDeviceGroupProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_INITIALIZATION_FAILED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkEnumeratePhysicalDeviceGroupsKHX(VkInstance instance, IntPtr pPhysicalDeviceGroupCount, ref VkPhysicalDeviceGroupPropertiesKHX pPhysicalDeviceGroupProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_INITIALIZATION_FAILED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkEnumeratePhysicalDeviceGroupsKHX(VkInstance instance, IntPtr pPhysicalDeviceGroupCount, IntPtr pPhysicalDeviceGroupProperties)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkEnumeratePhysicalDevices_ptr;
         ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_INITIALIZATION_FAILED</remarks>
         [Generator.CalliRewrite]
@@ -7226,6 +8061,86 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkGetBufferMemoryRequirements2KHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetBufferMemoryRequirements2KHR(VkDevice device, VkBufferMemoryRequirementsInfo2KHR* pInfo, VkMemoryRequirements2KHR* pMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetBufferMemoryRequirements2KHR(VkDevice device, VkBufferMemoryRequirementsInfo2KHR* pInfo, out VkMemoryRequirements2KHR pMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetBufferMemoryRequirements2KHR(VkDevice device, ref VkBufferMemoryRequirementsInfo2KHR pInfo, VkMemoryRequirements2KHR* pMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetBufferMemoryRequirements2KHR(VkDevice device, ref VkBufferMemoryRequirementsInfo2KHR pInfo, out VkMemoryRequirements2KHR pMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetBufferMemoryRequirements2KHR(VkDevice device, IntPtr pInfo, VkMemoryRequirements2KHR* pMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetBufferMemoryRequirements2KHR(VkDevice device, IntPtr pInfo, out VkMemoryRequirements2KHR pMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetDeviceGroupPeerMemoryFeaturesKHX_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetDeviceGroupPeerMemoryFeaturesKHX(VkDevice device, uint heapIndex, uint localDeviceIndex, uint remoteDeviceIndex, VkPeerMemoryFeatureFlagsKHX* pPeerMemoryFeatures)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetDeviceGroupPeerMemoryFeaturesKHX(VkDevice device, uint heapIndex, uint localDeviceIndex, uint remoteDeviceIndex, out VkPeerMemoryFeatureFlagsKHX pPeerMemoryFeatures)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetDeviceGroupPresentCapabilitiesKHX_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetDeviceGroupPresentCapabilitiesKHX(VkDevice device, VkDeviceGroupPresentCapabilitiesKHX* pDeviceGroupPresentCapabilities)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetDeviceGroupPresentCapabilitiesKHX(VkDevice device, out VkDeviceGroupPresentCapabilitiesKHX pDeviceGroupPresentCapabilities)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetDeviceGroupSurfacePresentModesKHX_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetDeviceGroupSurfacePresentModesKHX(VkDevice device, VkSurfaceKHR surface, VkDeviceGroupPresentModeFlagsKHX* pModes)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetDeviceGroupSurfacePresentModesKHX(VkDevice device, VkSurfaceKHR surface, out VkDeviceGroupPresentModeFlagsKHX pModes)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkGetDeviceMemoryCommitment_ptr;
         [Generator.CalliRewrite]
         public static unsafe void vkGetDeviceMemoryCommitment(VkDevice device, VkDeviceMemory memory, ulong* pCommittedMemoryInBytes)
@@ -7374,10 +8289,96 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkGetFenceFdKHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetFenceFdKHR(VkDevice device, VkFenceGetFdInfoKHR* pGetFdInfo, int* pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetFenceFdKHR(VkDevice device, VkFenceGetFdInfoKHR* pGetFdInfo, out int pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetFenceFdKHR(VkDevice device, ref VkFenceGetFdInfoKHR pGetFdInfo, int* pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetFenceFdKHR(VkDevice device, ref VkFenceGetFdInfoKHR pGetFdInfo, out int pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetFenceFdKHR(VkDevice device, IntPtr pGetFdInfo, int* pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetFenceFdKHR(VkDevice device, IntPtr pGetFdInfo, out int pFd)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkGetFenceStatus_ptr;
         ///<remarks>Success codes:VK_SUCCESS, VK_NOT_READY. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_DEVICE_LOST</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkGetFenceStatus(VkDevice device, VkFence fence)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetFenceWin32HandleKHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetFenceWin32HandleKHR(VkDevice device, VkFenceGetWin32HandleInfoKHR* pGetWin32HandleInfo, Win32.HANDLE* pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetFenceWin32HandleKHR(VkDevice device, VkFenceGetWin32HandleInfoKHR* pGetWin32HandleInfo, out Win32.HANDLE pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetFenceWin32HandleKHR(VkDevice device, ref VkFenceGetWin32HandleInfoKHR pGetWin32HandleInfo, Win32.HANDLE* pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetFenceWin32HandleKHR(VkDevice device, ref VkFenceGetWin32HandleInfoKHR pGetWin32HandleInfo, out Win32.HANDLE pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetFenceWin32HandleKHR(VkDevice device, IntPtr pGetWin32HandleInfo, Win32.HANDLE* pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetFenceWin32HandleKHR(VkDevice device, IntPtr pGetWin32HandleInfo, out Win32.HANDLE pHandle)
         {
             throw new NotImplementedException();
         }
@@ -7391,6 +8392,43 @@ namespace Vulkan
 
         [Generator.CalliRewrite]
         public static unsafe void vkGetImageMemoryRequirements(VkDevice device, VkImage image, out VkMemoryRequirements pMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetImageMemoryRequirements2KHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageMemoryRequirements2KHR(VkDevice device, VkImageMemoryRequirementsInfo2KHR* pInfo, VkMemoryRequirements2KHR* pMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageMemoryRequirements2KHR(VkDevice device, VkImageMemoryRequirementsInfo2KHR* pInfo, out VkMemoryRequirements2KHR pMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageMemoryRequirements2KHR(VkDevice device, ref VkImageMemoryRequirementsInfo2KHR pInfo, VkMemoryRequirements2KHR* pMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageMemoryRequirements2KHR(VkDevice device, ref VkImageMemoryRequirementsInfo2KHR pInfo, out VkMemoryRequirements2KHR pMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageMemoryRequirements2KHR(VkDevice device, IntPtr pInfo, VkMemoryRequirements2KHR* pMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageMemoryRequirements2KHR(VkDevice device, IntPtr pInfo, out VkMemoryRequirements2KHR pMemoryRequirements)
         {
             throw new NotImplementedException();
         }
@@ -7428,6 +8466,115 @@ namespace Vulkan
 
         [Generator.CalliRewrite]
         public static unsafe void vkGetImageSparseMemoryRequirements(VkDevice device, VkImage image, IntPtr pSparseMemoryRequirementCount, out VkSparseImageMemoryRequirements pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetImageSparseMemoryRequirements2KHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, VkImageSparseMemoryRequirementsInfo2KHR* pInfo, uint* pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2KHR* pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, VkImageSparseMemoryRequirementsInfo2KHR* pInfo, uint* pSparseMemoryRequirementCount, out VkSparseImageMemoryRequirements2KHR pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, VkImageSparseMemoryRequirementsInfo2KHR* pInfo, ref uint pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2KHR* pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, VkImageSparseMemoryRequirementsInfo2KHR* pInfo, ref uint pSparseMemoryRequirementCount, out VkSparseImageMemoryRequirements2KHR pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, VkImageSparseMemoryRequirementsInfo2KHR* pInfo, IntPtr pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2KHR* pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, VkImageSparseMemoryRequirementsInfo2KHR* pInfo, IntPtr pSparseMemoryRequirementCount, out VkSparseImageMemoryRequirements2KHR pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, ref VkImageSparseMemoryRequirementsInfo2KHR pInfo, uint* pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2KHR* pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, ref VkImageSparseMemoryRequirementsInfo2KHR pInfo, uint* pSparseMemoryRequirementCount, out VkSparseImageMemoryRequirements2KHR pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, ref VkImageSparseMemoryRequirementsInfo2KHR pInfo, ref uint pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2KHR* pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, ref VkImageSparseMemoryRequirementsInfo2KHR pInfo, ref uint pSparseMemoryRequirementCount, out VkSparseImageMemoryRequirements2KHR pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, ref VkImageSparseMemoryRequirementsInfo2KHR pInfo, IntPtr pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2KHR* pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, ref VkImageSparseMemoryRequirementsInfo2KHR pInfo, IntPtr pSparseMemoryRequirementCount, out VkSparseImageMemoryRequirements2KHR pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, IntPtr pInfo, uint* pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2KHR* pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, IntPtr pInfo, uint* pSparseMemoryRequirementCount, out VkSparseImageMemoryRequirements2KHR pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, IntPtr pInfo, ref uint pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2KHR* pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, IntPtr pInfo, ref uint pSparseMemoryRequirementCount, out VkSparseImageMemoryRequirements2KHR pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, IntPtr pInfo, IntPtr pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2KHR* pSparseMemoryRequirements)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetImageSparseMemoryRequirements2KHR(VkDevice device, IntPtr pInfo, IntPtr pSparseMemoryRequirementCount, out VkSparseImageMemoryRequirements2KHR pSparseMemoryRequirements)
         {
             throw new NotImplementedException();
         }
@@ -7482,6 +8629,107 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkGetMemoryFdKHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryFdKHR(VkDevice device, VkMemoryGetFdInfoKHR* pGetFdInfo, int* pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryFdKHR(VkDevice device, VkMemoryGetFdInfoKHR* pGetFdInfo, out int pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryFdKHR(VkDevice device, ref VkMemoryGetFdInfoKHR pGetFdInfo, int* pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryFdKHR(VkDevice device, ref VkMemoryGetFdInfoKHR pGetFdInfo, out int pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryFdKHR(VkDevice device, IntPtr pGetFdInfo, int* pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryFdKHR(VkDevice device, IntPtr pGetFdInfo, out int pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetMemoryFdPropertiesKHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryFdPropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagsKHR handleType, int fd, VkMemoryFdPropertiesKHR* pMemoryFdProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryFdPropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagsKHR handleType, int fd, out VkMemoryFdPropertiesKHR pMemoryFdProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetMemoryWin32HandleKHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryWin32HandleKHR(VkDevice device, VkMemoryGetWin32HandleInfoKHR* pGetWin32HandleInfo, Win32.HANDLE* pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryWin32HandleKHR(VkDevice device, VkMemoryGetWin32HandleInfoKHR* pGetWin32HandleInfo, out Win32.HANDLE pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryWin32HandleKHR(VkDevice device, ref VkMemoryGetWin32HandleInfoKHR pGetWin32HandleInfo, Win32.HANDLE* pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryWin32HandleKHR(VkDevice device, ref VkMemoryGetWin32HandleInfoKHR pGetWin32HandleInfo, out Win32.HANDLE pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryWin32HandleKHR(VkDevice device, IntPtr pGetWin32HandleInfo, Win32.HANDLE* pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryWin32HandleKHR(VkDevice device, IntPtr pGetWin32HandleInfo, out Win32.HANDLE pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkGetMemoryWin32HandleNV_ptr;
         ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
         [Generator.CalliRewrite]
@@ -7493,6 +8741,64 @@ namespace Vulkan
         ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkGetMemoryWin32HandleNV(VkDevice device, VkDeviceMemory memory, VkExternalMemoryHandleTypeFlagsNV handleType, out Win32.HANDLE pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetMemoryWin32HandlePropertiesKHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryWin32HandlePropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagsKHR handleType, Win32.HANDLE handle, VkMemoryWin32HandlePropertiesKHR* pMemoryWin32HandleProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetMemoryWin32HandlePropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagsKHR handleType, Win32.HANDLE handle, out VkMemoryWin32HandlePropertiesKHR pMemoryWin32HandleProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetPastPresentationTimingGOOGLE_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPastPresentationTimingGOOGLE(VkDevice device, VkSwapchainKHR swapchain, uint* pPresentationTimingCount, VkPastPresentationTimingGOOGLE* pPresentationTimings)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPastPresentationTimingGOOGLE(VkDevice device, VkSwapchainKHR swapchain, uint* pPresentationTimingCount, out VkPastPresentationTimingGOOGLE pPresentationTimings)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPastPresentationTimingGOOGLE(VkDevice device, VkSwapchainKHR swapchain, ref uint pPresentationTimingCount, VkPastPresentationTimingGOOGLE* pPresentationTimings)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPastPresentationTimingGOOGLE(VkDevice device, VkSwapchainKHR swapchain, ref uint pPresentationTimingCount, out VkPastPresentationTimingGOOGLE pPresentationTimings)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPastPresentationTimingGOOGLE(VkDevice device, VkSwapchainKHR swapchain, IntPtr pPresentationTimingCount, VkPastPresentationTimingGOOGLE* pPresentationTimings)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPastPresentationTimingGOOGLE(VkDevice device, VkSwapchainKHR swapchain, IntPtr pPresentationTimingCount, out VkPastPresentationTimingGOOGLE pPresentationTimings)
         {
             throw new NotImplementedException();
         }
@@ -7583,6 +8889,80 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkGetPhysicalDeviceExternalBufferPropertiesKHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalBufferPropertiesKHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceExternalBufferInfoKHR* pExternalBufferInfo, VkExternalBufferPropertiesKHR* pExternalBufferProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalBufferPropertiesKHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceExternalBufferInfoKHR* pExternalBufferInfo, out VkExternalBufferPropertiesKHR pExternalBufferProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalBufferPropertiesKHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceExternalBufferInfoKHR pExternalBufferInfo, VkExternalBufferPropertiesKHR* pExternalBufferProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalBufferPropertiesKHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceExternalBufferInfoKHR pExternalBufferInfo, out VkExternalBufferPropertiesKHR pExternalBufferProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalBufferPropertiesKHR(VkPhysicalDevice physicalDevice, IntPtr pExternalBufferInfo, VkExternalBufferPropertiesKHR* pExternalBufferProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalBufferPropertiesKHR(VkPhysicalDevice physicalDevice, IntPtr pExternalBufferInfo, out VkExternalBufferPropertiesKHR pExternalBufferProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetPhysicalDeviceExternalFencePropertiesKHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalFencePropertiesKHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceExternalFenceInfoKHR* pExternalFenceInfo, VkExternalFencePropertiesKHR* pExternalFenceProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalFencePropertiesKHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceExternalFenceInfoKHR* pExternalFenceInfo, out VkExternalFencePropertiesKHR pExternalFenceProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalFencePropertiesKHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceExternalFenceInfoKHR pExternalFenceInfo, VkExternalFencePropertiesKHR* pExternalFenceProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalFencePropertiesKHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceExternalFenceInfoKHR pExternalFenceInfo, out VkExternalFencePropertiesKHR pExternalFenceProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalFencePropertiesKHR(VkPhysicalDevice physicalDevice, IntPtr pExternalFenceInfo, VkExternalFencePropertiesKHR* pExternalFenceProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalFencePropertiesKHR(VkPhysicalDevice physicalDevice, IntPtr pExternalFenceInfo, out VkExternalFencePropertiesKHR pExternalFenceProperties)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkGetPhysicalDeviceExternalImageFormatPropertiesNV_ptr;
         ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FORMAT_NOT_SUPPORTED</remarks>
         [Generator.CalliRewrite]
@@ -7594,6 +8974,43 @@ namespace Vulkan
         ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FORMAT_NOT_SUPPORTED</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkGetPhysicalDeviceExternalImageFormatPropertiesNV(VkPhysicalDevice physicalDevice, VkFormat format, VkImageType type, VkImageTiling tiling, VkImageUsageFlags usage, VkImageCreateFlags flags, VkExternalMemoryHandleTypeFlagsNV externalHandleType, out VkExternalImageFormatPropertiesNV pExternalImageFormatProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetPhysicalDeviceExternalSemaphorePropertiesKHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceExternalSemaphoreInfoKHR* pExternalSemaphoreInfo, VkExternalSemaphorePropertiesKHR* pExternalSemaphoreProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceExternalSemaphoreInfoKHR* pExternalSemaphoreInfo, out VkExternalSemaphorePropertiesKHR pExternalSemaphoreProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceExternalSemaphoreInfoKHR pExternalSemaphoreInfo, VkExternalSemaphorePropertiesKHR* pExternalSemaphoreProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceExternalSemaphoreInfoKHR pExternalSemaphoreInfo, out VkExternalSemaphorePropertiesKHR pExternalSemaphoreProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(VkPhysicalDevice physicalDevice, IntPtr pExternalSemaphoreInfo, VkExternalSemaphorePropertiesKHR* pExternalSemaphoreProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(VkPhysicalDevice physicalDevice, IntPtr pExternalSemaphoreInfo, out VkExternalSemaphorePropertiesKHR pExternalSemaphoreProperties)
         {
             throw new NotImplementedException();
         }
@@ -7611,6 +9028,19 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkGetPhysicalDeviceFeatures2KHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceFeatures2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures2KHR* pFeatures)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceFeatures2KHR(VkPhysicalDevice physicalDevice, out VkPhysicalDeviceFeatures2KHR pFeatures)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkGetPhysicalDeviceFormatProperties_ptr;
         [Generator.CalliRewrite]
         public static unsafe void vkGetPhysicalDeviceFormatProperties(VkPhysicalDevice physicalDevice, VkFormat format, VkFormatProperties* pFormatProperties)
@@ -7620,6 +9050,19 @@ namespace Vulkan
 
         [Generator.CalliRewrite]
         public static unsafe void vkGetPhysicalDeviceFormatProperties(VkPhysicalDevice physicalDevice, VkFormat format, out VkFormatProperties pFormatProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetPhysicalDeviceFormatProperties2KHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceFormatProperties2KHR(VkPhysicalDevice physicalDevice, VkFormat format, VkFormatProperties2KHR* pFormatProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceFormatProperties2KHR(VkPhysicalDevice physicalDevice, VkFormat format, out VkFormatProperties2KHR pFormatProperties)
         {
             throw new NotImplementedException();
         }
@@ -7676,6 +9119,49 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkGetPhysicalDeviceImageFormatProperties2KHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FORMAT_NOT_SUPPORTED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceImageFormatInfo2KHR* pImageFormatInfo, VkImageFormatProperties2KHR* pImageFormatProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FORMAT_NOT_SUPPORTED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceImageFormatInfo2KHR* pImageFormatInfo, out VkImageFormatProperties2KHR pImageFormatProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FORMAT_NOT_SUPPORTED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceImageFormatInfo2KHR pImageFormatInfo, VkImageFormatProperties2KHR* pImageFormatProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FORMAT_NOT_SUPPORTED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceImageFormatInfo2KHR pImageFormatInfo, out VkImageFormatProperties2KHR pImageFormatProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FORMAT_NOT_SUPPORTED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, IntPtr pImageFormatInfo, VkImageFormatProperties2KHR* pImageFormatProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_FORMAT_NOT_SUPPORTED</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, IntPtr pImageFormatInfo, out VkImageFormatProperties2KHR pImageFormatProperties)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkGetPhysicalDeviceMemoryProperties_ptr;
         [Generator.CalliRewrite]
         public static unsafe void vkGetPhysicalDeviceMemoryProperties(VkPhysicalDevice physicalDevice, VkPhysicalDeviceMemoryProperties* pMemoryProperties)
@@ -7685,6 +9171,19 @@ namespace Vulkan
 
         [Generator.CalliRewrite]
         public static unsafe void vkGetPhysicalDeviceMemoryProperties(VkPhysicalDevice physicalDevice, out VkPhysicalDeviceMemoryProperties pMemoryProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetPhysicalDeviceMemoryProperties2KHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceMemoryProperties2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceMemoryProperties2KHR* pMemoryProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceMemoryProperties2KHR(VkPhysicalDevice physicalDevice, out VkPhysicalDeviceMemoryProperties2KHR pMemoryProperties)
         {
             throw new NotImplementedException();
         }
@@ -7702,6 +9201,49 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkGetPhysicalDevicePresentRectanglesKHX_ptr;
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDevicePresentRectanglesKHX(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, uint* pRectCount, VkRect2D* pRects)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDevicePresentRectanglesKHX(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, uint* pRectCount, out VkRect2D pRects)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDevicePresentRectanglesKHX(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, ref uint pRectCount, VkRect2D* pRects)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDevicePresentRectanglesKHX(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, ref uint pRectCount, out VkRect2D pRects)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDevicePresentRectanglesKHX(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, IntPtr pRectCount, VkRect2D* pRects)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDevicePresentRectanglesKHX(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, IntPtr pRectCount, out VkRect2D pRects)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkGetPhysicalDeviceProperties_ptr;
         [Generator.CalliRewrite]
         public static unsafe void vkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties* pProperties)
@@ -7711,6 +9253,19 @@ namespace Vulkan
 
         [Generator.CalliRewrite]
         public static unsafe void vkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice, out VkPhysicalDeviceProperties pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetPhysicalDeviceProperties2KHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties2KHR* pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice physicalDevice, out VkPhysicalDeviceProperties2KHR pProperties)
         {
             throw new NotImplementedException();
         }
@@ -7752,6 +9307,43 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkGetPhysicalDeviceQueueFamilyProperties2KHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceQueueFamilyProperties2KHR(VkPhysicalDevice physicalDevice, uint* pQueueFamilyPropertyCount, VkQueueFamilyProperties2KHR* pQueueFamilyProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceQueueFamilyProperties2KHR(VkPhysicalDevice physicalDevice, uint* pQueueFamilyPropertyCount, out VkQueueFamilyProperties2KHR pQueueFamilyProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceQueueFamilyProperties2KHR(VkPhysicalDevice physicalDevice, ref uint pQueueFamilyPropertyCount, VkQueueFamilyProperties2KHR* pQueueFamilyProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceQueueFamilyProperties2KHR(VkPhysicalDevice physicalDevice, ref uint pQueueFamilyPropertyCount, out VkQueueFamilyProperties2KHR pQueueFamilyProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceQueueFamilyProperties2KHR(VkPhysicalDevice physicalDevice, IntPtr pQueueFamilyPropertyCount, VkQueueFamilyProperties2KHR* pQueueFamilyProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceQueueFamilyProperties2KHR(VkPhysicalDevice physicalDevice, IntPtr pQueueFamilyPropertyCount, out VkQueueFamilyProperties2KHR pQueueFamilyProperties)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkGetPhysicalDeviceSparseImageFormatProperties_ptr;
         [Generator.CalliRewrite]
         public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties(VkPhysicalDevice physicalDevice, VkFormat format, VkImageType type, VkSampleCountFlags samples, VkImageUsageFlags usage, VkImageTiling tiling, uint* pPropertyCount, VkSparseImageFormatProperties* pProperties)
@@ -7789,6 +9381,173 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkGetPhysicalDeviceSparseImageFormatProperties2KHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceSparseImageFormatInfo2KHR* pFormatInfo, uint* pPropertyCount, VkSparseImageFormatProperties2KHR* pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceSparseImageFormatInfo2KHR* pFormatInfo, uint* pPropertyCount, out VkSparseImageFormatProperties2KHR pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceSparseImageFormatInfo2KHR* pFormatInfo, ref uint pPropertyCount, VkSparseImageFormatProperties2KHR* pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceSparseImageFormatInfo2KHR* pFormatInfo, ref uint pPropertyCount, out VkSparseImageFormatProperties2KHR pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceSparseImageFormatInfo2KHR* pFormatInfo, IntPtr pPropertyCount, VkSparseImageFormatProperties2KHR* pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceSparseImageFormatInfo2KHR* pFormatInfo, IntPtr pPropertyCount, out VkSparseImageFormatProperties2KHR pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceSparseImageFormatInfo2KHR pFormatInfo, uint* pPropertyCount, VkSparseImageFormatProperties2KHR* pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceSparseImageFormatInfo2KHR pFormatInfo, uint* pPropertyCount, out VkSparseImageFormatProperties2KHR pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceSparseImageFormatInfo2KHR pFormatInfo, ref uint pPropertyCount, VkSparseImageFormatProperties2KHR* pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceSparseImageFormatInfo2KHR pFormatInfo, ref uint pPropertyCount, out VkSparseImageFormatProperties2KHR pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceSparseImageFormatInfo2KHR pFormatInfo, IntPtr pPropertyCount, VkSparseImageFormatProperties2KHR* pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceSparseImageFormatInfo2KHR pFormatInfo, IntPtr pPropertyCount, out VkSparseImageFormatProperties2KHR pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, IntPtr pFormatInfo, uint* pPropertyCount, VkSparseImageFormatProperties2KHR* pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, IntPtr pFormatInfo, uint* pPropertyCount, out VkSparseImageFormatProperties2KHR pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, IntPtr pFormatInfo, ref uint pPropertyCount, VkSparseImageFormatProperties2KHR* pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, IntPtr pFormatInfo, ref uint pPropertyCount, out VkSparseImageFormatProperties2KHR pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, IntPtr pFormatInfo, IntPtr pPropertyCount, VkSparseImageFormatProperties2KHR* pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(VkPhysicalDevice physicalDevice, IntPtr pFormatInfo, IntPtr pPropertyCount, out VkSparseImageFormatProperties2KHR pProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetPhysicalDeviceSurfaceCapabilities2EXT_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilities2EXT* pSurfaceCapabilities)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, out VkSurfaceCapabilities2EXT pSurfaceCapabilities)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetPhysicalDeviceSurfaceCapabilities2KHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, VkSurfaceCapabilities2KHR* pSurfaceCapabilities)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, out VkSurfaceCapabilities2KHR pSurfaceCapabilities)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceSurfaceInfo2KHR pSurfaceInfo, VkSurfaceCapabilities2KHR* pSurfaceCapabilities)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceSurfaceInfo2KHR pSurfaceInfo, out VkSurfaceCapabilities2KHR pSurfaceCapabilities)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhysicalDevice physicalDevice, IntPtr pSurfaceInfo, VkSurfaceCapabilities2KHR* pSurfaceCapabilities)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhysicalDevice physicalDevice, IntPtr pSurfaceInfo, out VkSurfaceCapabilities2KHR pSurfaceCapabilities)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkGetPhysicalDeviceSurfaceCapabilitiesKHR_ptr;
         ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
         [Generator.CalliRewrite]
@@ -7800,6 +9559,133 @@ namespace Vulkan
         ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, out VkSurfaceCapabilitiesKHR pSurfaceCapabilities)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetPhysicalDeviceSurfaceFormats2KHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, uint* pSurfaceFormatCount, VkSurfaceFormat2KHR* pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, uint* pSurfaceFormatCount, out VkSurfaceFormat2KHR pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, ref uint pSurfaceFormatCount, VkSurfaceFormat2KHR* pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, ref uint pSurfaceFormatCount, out VkSurfaceFormat2KHR pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, IntPtr pSurfaceFormatCount, VkSurfaceFormat2KHR* pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, IntPtr pSurfaceFormatCount, out VkSurfaceFormat2KHR pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceSurfaceInfo2KHR pSurfaceInfo, uint* pSurfaceFormatCount, VkSurfaceFormat2KHR* pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceSurfaceInfo2KHR pSurfaceInfo, uint* pSurfaceFormatCount, out VkSurfaceFormat2KHR pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceSurfaceInfo2KHR pSurfaceInfo, ref uint pSurfaceFormatCount, VkSurfaceFormat2KHR* pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceSurfaceInfo2KHR pSurfaceInfo, ref uint pSurfaceFormatCount, out VkSurfaceFormat2KHR pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceSurfaceInfo2KHR pSurfaceInfo, IntPtr pSurfaceFormatCount, VkSurfaceFormat2KHR* pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, ref VkPhysicalDeviceSurfaceInfo2KHR pSurfaceInfo, IntPtr pSurfaceFormatCount, out VkSurfaceFormat2KHR pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, IntPtr pSurfaceInfo, uint* pSurfaceFormatCount, VkSurfaceFormat2KHR* pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, IntPtr pSurfaceInfo, uint* pSurfaceFormatCount, out VkSurfaceFormat2KHR pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, IntPtr pSurfaceInfo, ref uint pSurfaceFormatCount, VkSurfaceFormat2KHR* pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, IntPtr pSurfaceInfo, ref uint pSurfaceFormatCount, out VkSurfaceFormat2KHR pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, IntPtr pSurfaceInfo, IntPtr pSurfaceFormatCount, VkSurfaceFormat2KHR* pSurfaceFormats)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, IntPtr pSurfaceInfo, IntPtr pSurfaceFormatCount, out VkSurfaceFormat2KHR pSurfaceFormats)
         {
             throw new NotImplementedException();
         }
@@ -7993,6 +9879,64 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkGetRandROutputDisplayEXT_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetRandROutputDisplayEXT(VkPhysicalDevice physicalDevice, Xlib.Display* dpy, IntPtr rrOutput, VkDisplayKHR* pDisplay)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetRandROutputDisplayEXT(VkPhysicalDevice physicalDevice, Xlib.Display* dpy, IntPtr rrOutput, out VkDisplayKHR pDisplay)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetRandROutputDisplayEXT(VkPhysicalDevice physicalDevice, ref Xlib.Display dpy, IntPtr rrOutput, VkDisplayKHR* pDisplay)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetRandROutputDisplayEXT(VkPhysicalDevice physicalDevice, ref Xlib.Display dpy, IntPtr rrOutput, out VkDisplayKHR pDisplay)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetRandROutputDisplayEXT(VkPhysicalDevice physicalDevice, IntPtr dpy, IntPtr rrOutput, VkDisplayKHR* pDisplay)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetRandROutputDisplayEXT(VkPhysicalDevice physicalDevice, IntPtr dpy, IntPtr rrOutput, out VkDisplayKHR pDisplay)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetRefreshCycleDurationGOOGLE_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_DEVICE_LOST, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetRefreshCycleDurationGOOGLE(VkDevice device, VkSwapchainKHR swapchain, VkRefreshCycleDurationGOOGLE* pDisplayTimingProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_DEVICE_LOST, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetRefreshCycleDurationGOOGLE(VkDevice device, VkSwapchainKHR swapchain, out VkRefreshCycleDurationGOOGLE pDisplayTimingProperties)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkGetRenderAreaGranularity_ptr;
         [Generator.CalliRewrite]
         public static unsafe void vkGetRenderAreaGranularity(VkDevice device, VkRenderPass renderPass, VkExtent2D* pGranularity)
@@ -8002,6 +9946,107 @@ namespace Vulkan
 
         [Generator.CalliRewrite]
         public static unsafe void vkGetRenderAreaGranularity(VkDevice device, VkRenderPass renderPass, out VkExtent2D pGranularity)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetSemaphoreFdKHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetSemaphoreFdKHR(VkDevice device, VkSemaphoreGetFdInfoKHR* pGetFdInfo, int* pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetSemaphoreFdKHR(VkDevice device, VkSemaphoreGetFdInfoKHR* pGetFdInfo, out int pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetSemaphoreFdKHR(VkDevice device, ref VkSemaphoreGetFdInfoKHR pGetFdInfo, int* pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetSemaphoreFdKHR(VkDevice device, ref VkSemaphoreGetFdInfoKHR pGetFdInfo, out int pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetSemaphoreFdKHR(VkDevice device, IntPtr pGetFdInfo, int* pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetSemaphoreFdKHR(VkDevice device, IntPtr pGetFdInfo, out int pFd)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetSemaphoreWin32HandleKHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetSemaphoreWin32HandleKHR(VkDevice device, VkSemaphoreGetWin32HandleInfoKHR* pGetWin32HandleInfo, Win32.HANDLE* pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetSemaphoreWin32HandleKHR(VkDevice device, VkSemaphoreGetWin32HandleInfoKHR* pGetWin32HandleInfo, out Win32.HANDLE pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetSemaphoreWin32HandleKHR(VkDevice device, ref VkSemaphoreGetWin32HandleInfoKHR pGetWin32HandleInfo, Win32.HANDLE* pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetSemaphoreWin32HandleKHR(VkDevice device, ref VkSemaphoreGetWin32HandleInfoKHR pGetWin32HandleInfo, out Win32.HANDLE pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetSemaphoreWin32HandleKHR(VkDevice device, IntPtr pGetWin32HandleInfo, Win32.HANDLE* pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_TOO_MANY_OBJECTS, VK_ERROR_OUT_OF_HOST_MEMORY</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetSemaphoreWin32HandleKHR(VkDevice device, IntPtr pGetWin32HandleInfo, out Win32.HANDLE pHandle)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetSwapchainCounterEXT_ptr;
+        ///<remarks>Success codes:VK_SUCCESS, VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetSwapchainCounterEXT(VkDevice device, VkSwapchainKHR swapchain, VkSurfaceCounterFlagsEXT counter, ulong* pCounterValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS, VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetSwapchainCounterEXT(VkDevice device, VkSwapchainKHR swapchain, VkSurfaceCounterFlagsEXT counter, out ulong pCounterValue)
         {
             throw new NotImplementedException();
         }
@@ -8045,6 +10090,102 @@ namespace Vulkan
         ///<remarks>Success codes:VK_SUCCESS, VK_INCOMPLETE. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, IntPtr pSwapchainImageCount, out VkImage pSwapchainImages)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkGetSwapchainStatusKHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS, VK_SUBOPTIMAL_KHR. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_DEVICE_LOST, VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_SURFACE_LOST_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkGetSwapchainStatusKHR(VkDevice device, VkSwapchainKHR swapchain)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkImportFenceFdKHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkImportFenceFdKHR(VkDevice device, VkImportFenceFdInfoKHR* pImportFenceFdInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkImportFenceFdKHR(VkDevice device, ref VkImportFenceFdInfoKHR pImportFenceFdInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkImportFenceFdKHR(VkDevice device, IntPtr pImportFenceFdInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkImportFenceWin32HandleKHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkImportFenceWin32HandleKHR(VkDevice device, VkImportFenceWin32HandleInfoKHR* pImportFenceWin32HandleInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkImportFenceWin32HandleKHR(VkDevice device, ref VkImportFenceWin32HandleInfoKHR pImportFenceWin32HandleInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkImportFenceWin32HandleKHR(VkDevice device, IntPtr pImportFenceWin32HandleInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkImportSemaphoreFdKHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkImportSemaphoreFdKHR(VkDevice device, VkImportSemaphoreFdInfoKHR* pImportSemaphoreFdInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkImportSemaphoreFdKHR(VkDevice device, ref VkImportSemaphoreFdInfoKHR pImportSemaphoreFdInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkImportSemaphoreFdKHR(VkDevice device, IntPtr pImportSemaphoreFdInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkImportSemaphoreWin32HandleKHR_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkImportSemaphoreWin32HandleKHR(VkDevice device, VkImportSemaphoreWin32HandleInfoKHR* pImportSemaphoreWin32HandleInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkImportSemaphoreWin32HandleKHR(VkDevice device, ref VkImportSemaphoreWin32HandleInfoKHR pImportSemaphoreWin32HandleInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkImportSemaphoreWin32HandleKHR(VkDevice device, IntPtr pImportSemaphoreWin32HandleInfo)
         {
             throw new NotImplementedException();
         }
@@ -8175,6 +10316,386 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkRegisterDeviceEventEXT_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, VkDeviceEventInfoEXT* pDeviceEventInfo, VkAllocationCallbacks* pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, VkDeviceEventInfoEXT* pDeviceEventInfo, VkAllocationCallbacks* pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, VkDeviceEventInfoEXT* pDeviceEventInfo, VkAllocationCallbacks* pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, VkDeviceEventInfoEXT* pDeviceEventInfo, ref VkAllocationCallbacks pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, VkDeviceEventInfoEXT* pDeviceEventInfo, ref VkAllocationCallbacks pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, VkDeviceEventInfoEXT* pDeviceEventInfo, ref VkAllocationCallbacks pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, VkDeviceEventInfoEXT* pDeviceEventInfo, IntPtr pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, VkDeviceEventInfoEXT* pDeviceEventInfo, IntPtr pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, VkDeviceEventInfoEXT* pDeviceEventInfo, IntPtr pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, ref VkDeviceEventInfoEXT pDeviceEventInfo, VkAllocationCallbacks* pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, ref VkDeviceEventInfoEXT pDeviceEventInfo, VkAllocationCallbacks* pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, ref VkDeviceEventInfoEXT pDeviceEventInfo, VkAllocationCallbacks* pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, ref VkDeviceEventInfoEXT pDeviceEventInfo, ref VkAllocationCallbacks pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, ref VkDeviceEventInfoEXT pDeviceEventInfo, ref VkAllocationCallbacks pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, ref VkDeviceEventInfoEXT pDeviceEventInfo, ref VkAllocationCallbacks pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, ref VkDeviceEventInfoEXT pDeviceEventInfo, IntPtr pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, ref VkDeviceEventInfoEXT pDeviceEventInfo, IntPtr pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, ref VkDeviceEventInfoEXT pDeviceEventInfo, IntPtr pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, IntPtr pDeviceEventInfo, VkAllocationCallbacks* pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, IntPtr pDeviceEventInfo, VkAllocationCallbacks* pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, IntPtr pDeviceEventInfo, VkAllocationCallbacks* pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, IntPtr pDeviceEventInfo, ref VkAllocationCallbacks pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, IntPtr pDeviceEventInfo, ref VkAllocationCallbacks pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, IntPtr pDeviceEventInfo, ref VkAllocationCallbacks pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, IntPtr pDeviceEventInfo, IntPtr pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, IntPtr pDeviceEventInfo, IntPtr pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDeviceEventEXT(VkDevice device, IntPtr pDeviceEventInfo, IntPtr pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkRegisterDisplayEventEXT_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, VkDisplayEventInfoEXT* pDisplayEventInfo, VkAllocationCallbacks* pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, VkDisplayEventInfoEXT* pDisplayEventInfo, VkAllocationCallbacks* pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, VkDisplayEventInfoEXT* pDisplayEventInfo, VkAllocationCallbacks* pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, VkDisplayEventInfoEXT* pDisplayEventInfo, ref VkAllocationCallbacks pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, VkDisplayEventInfoEXT* pDisplayEventInfo, ref VkAllocationCallbacks pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, VkDisplayEventInfoEXT* pDisplayEventInfo, ref VkAllocationCallbacks pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, VkDisplayEventInfoEXT* pDisplayEventInfo, IntPtr pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, VkDisplayEventInfoEXT* pDisplayEventInfo, IntPtr pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, VkDisplayEventInfoEXT* pDisplayEventInfo, IntPtr pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, ref VkDisplayEventInfoEXT pDisplayEventInfo, VkAllocationCallbacks* pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, ref VkDisplayEventInfoEXT pDisplayEventInfo, VkAllocationCallbacks* pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, ref VkDisplayEventInfoEXT pDisplayEventInfo, VkAllocationCallbacks* pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, ref VkDisplayEventInfoEXT pDisplayEventInfo, ref VkAllocationCallbacks pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, ref VkDisplayEventInfoEXT pDisplayEventInfo, ref VkAllocationCallbacks pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, ref VkDisplayEventInfoEXT pDisplayEventInfo, ref VkAllocationCallbacks pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, ref VkDisplayEventInfoEXT pDisplayEventInfo, IntPtr pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, ref VkDisplayEventInfoEXT pDisplayEventInfo, IntPtr pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, ref VkDisplayEventInfoEXT pDisplayEventInfo, IntPtr pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, IntPtr pDisplayEventInfo, VkAllocationCallbacks* pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, IntPtr pDisplayEventInfo, VkAllocationCallbacks* pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, IntPtr pDisplayEventInfo, VkAllocationCallbacks* pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, IntPtr pDisplayEventInfo, ref VkAllocationCallbacks pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, IntPtr pDisplayEventInfo, ref VkAllocationCallbacks pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, IntPtr pDisplayEventInfo, ref VkAllocationCallbacks pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, IntPtr pDisplayEventInfo, IntPtr pAllocator, VkFence* pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, IntPtr pDisplayEventInfo, IntPtr pAllocator, ref VkFence pFence)
+        {
+            throw new NotImplementedException();
+        }
+
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, IntPtr pDisplayEventInfo, IntPtr pAllocator, IntPtr pFence)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkRegisterObjectsNVX_ptr;
         ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
         [Generator.CalliRewrite]
@@ -8239,6 +10760,14 @@ namespace Vulkan
             throw new NotImplementedException();
         }
 
+        private static IntPtr vkReleaseDisplayEXT_ptr;
+        ///<remarks>Success codes:VK_SUCCESS. Error codes:</remarks>
+        [Generator.CalliRewrite]
+        public static unsafe VkResult vkReleaseDisplayEXT(VkPhysicalDevice physicalDevice, VkDisplayKHR display)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IntPtr vkResetCommandBuffer_ptr;
         ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
         [Generator.CalliRewrite]
@@ -8297,6 +10826,68 @@ namespace Vulkan
         ///<remarks>Success codes:VK_SUCCESS. Error codes:VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY</remarks>
         [Generator.CalliRewrite]
         public static unsafe VkResult vkSetEvent(VkDevice device, VkEvent @event)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkSetHdrMetadataEXT_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkSetHdrMetadataEXT(VkDevice device, uint swapchainCount, VkSwapchainKHR* pSwapchains, VkHdrMetadataEXT* pMetadata)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkSetHdrMetadataEXT(VkDevice device, uint swapchainCount, VkSwapchainKHR* pSwapchains, ref VkHdrMetadataEXT pMetadata)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkSetHdrMetadataEXT(VkDevice device, uint swapchainCount, VkSwapchainKHR* pSwapchains, IntPtr pMetadata)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkSetHdrMetadataEXT(VkDevice device, uint swapchainCount, ref VkSwapchainKHR pSwapchains, VkHdrMetadataEXT* pMetadata)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkSetHdrMetadataEXT(VkDevice device, uint swapchainCount, ref VkSwapchainKHR pSwapchains, ref VkHdrMetadataEXT pMetadata)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkSetHdrMetadataEXT(VkDevice device, uint swapchainCount, ref VkSwapchainKHR pSwapchains, IntPtr pMetadata)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkSetHdrMetadataEXT(VkDevice device, uint swapchainCount, IntPtr pSwapchains, VkHdrMetadataEXT* pMetadata)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkSetHdrMetadataEXT(VkDevice device, uint swapchainCount, IntPtr pSwapchains, ref VkHdrMetadataEXT pMetadata)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Generator.CalliRewrite]
+        public static unsafe void vkSetHdrMetadataEXT(VkDevice device, uint swapchainCount, IntPtr pSwapchains, IntPtr pMetadata)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkTrimCommandPoolKHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkTrimCommandPoolKHR(VkDevice device, VkCommandPool commandPool, uint flags)
         {
             throw new NotImplementedException();
         }
@@ -8423,6 +11014,13 @@ namespace Vulkan
 
         [Generator.CalliRewrite]
         public static unsafe void vkUpdateDescriptorSets(VkDevice device, uint descriptorWriteCount, IntPtr pDescriptorWrites, uint descriptorCopyCount, IntPtr pDescriptorCopies)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static IntPtr vkUpdateDescriptorSetWithTemplateKHR_ptr;
+        [Generator.CalliRewrite]
+        public static unsafe void vkUpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, void* pData)
         {
             throw new NotImplementedException();
         }
@@ -8609,6 +11207,7 @@ namespace Vulkan
             vkGetSwapchainImagesKHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetSwapchainImagesKHR");
             vkAcquireNextImageKHR_ptr = s_nativeLib.LoadFunctionPointer("vkAcquireNextImageKHR");
             vkQueuePresentKHR_ptr = s_nativeLib.LoadFunctionPointer("vkQueuePresentKHR");
+            vkCreateViSurfaceNN_ptr = s_nativeLib.LoadFunctionPointer("vkCreateViSurfaceNN");
             vkCreateWaylandSurfaceKHR_ptr = s_nativeLib.LoadFunctionPointer("vkCreateWaylandSurfaceKHR");
             vkGetPhysicalDeviceWaylandPresentationSupportKHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDeviceWaylandPresentationSupportKHR");
             vkCreateWin32SurfaceKHR_ptr = s_nativeLib.LoadFunctionPointer("vkCreateWin32SurfaceKHR");
@@ -8638,6 +11237,65 @@ namespace Vulkan
             vkRegisterObjectsNVX_ptr = s_nativeLib.LoadFunctionPointer("vkRegisterObjectsNVX");
             vkUnregisterObjectsNVX_ptr = s_nativeLib.LoadFunctionPointer("vkUnregisterObjectsNVX");
             vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX");
+            vkGetPhysicalDeviceFeatures2KHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDeviceFeatures2KHR");
+            vkGetPhysicalDeviceProperties2KHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDeviceProperties2KHR");
+            vkGetPhysicalDeviceFormatProperties2KHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDeviceFormatProperties2KHR");
+            vkGetPhysicalDeviceImageFormatProperties2KHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDeviceImageFormatProperties2KHR");
+            vkGetPhysicalDeviceQueueFamilyProperties2KHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDeviceQueueFamilyProperties2KHR");
+            vkGetPhysicalDeviceMemoryProperties2KHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDeviceMemoryProperties2KHR");
+            vkGetPhysicalDeviceSparseImageFormatProperties2KHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDeviceSparseImageFormatProperties2KHR");
+            vkCmdPushDescriptorSetKHR_ptr = s_nativeLib.LoadFunctionPointer("vkCmdPushDescriptorSetKHR");
+            vkTrimCommandPoolKHR_ptr = s_nativeLib.LoadFunctionPointer("vkTrimCommandPoolKHR");
+            vkGetPhysicalDeviceExternalBufferPropertiesKHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDeviceExternalBufferPropertiesKHR");
+            vkGetMemoryWin32HandleKHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetMemoryWin32HandleKHR");
+            vkGetMemoryWin32HandlePropertiesKHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetMemoryWin32HandlePropertiesKHR");
+            vkGetMemoryFdKHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetMemoryFdKHR");
+            vkGetMemoryFdPropertiesKHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetMemoryFdPropertiesKHR");
+            vkGetPhysicalDeviceExternalSemaphorePropertiesKHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
+            vkGetSemaphoreWin32HandleKHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetSemaphoreWin32HandleKHR");
+            vkImportSemaphoreWin32HandleKHR_ptr = s_nativeLib.LoadFunctionPointer("vkImportSemaphoreWin32HandleKHR");
+            vkGetSemaphoreFdKHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetSemaphoreFdKHR");
+            vkImportSemaphoreFdKHR_ptr = s_nativeLib.LoadFunctionPointer("vkImportSemaphoreFdKHR");
+            vkGetPhysicalDeviceExternalFencePropertiesKHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDeviceExternalFencePropertiesKHR");
+            vkGetFenceWin32HandleKHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetFenceWin32HandleKHR");
+            vkImportFenceWin32HandleKHR_ptr = s_nativeLib.LoadFunctionPointer("vkImportFenceWin32HandleKHR");
+            vkGetFenceFdKHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetFenceFdKHR");
+            vkImportFenceFdKHR_ptr = s_nativeLib.LoadFunctionPointer("vkImportFenceFdKHR");
+            vkReleaseDisplayEXT_ptr = s_nativeLib.LoadFunctionPointer("vkReleaseDisplayEXT");
+            vkAcquireXlibDisplayEXT_ptr = s_nativeLib.LoadFunctionPointer("vkAcquireXlibDisplayEXT");
+            vkGetRandROutputDisplayEXT_ptr = s_nativeLib.LoadFunctionPointer("vkGetRandROutputDisplayEXT");
+            vkDisplayPowerControlEXT_ptr = s_nativeLib.LoadFunctionPointer("vkDisplayPowerControlEXT");
+            vkRegisterDeviceEventEXT_ptr = s_nativeLib.LoadFunctionPointer("vkRegisterDeviceEventEXT");
+            vkRegisterDisplayEventEXT_ptr = s_nativeLib.LoadFunctionPointer("vkRegisterDisplayEventEXT");
+            vkGetSwapchainCounterEXT_ptr = s_nativeLib.LoadFunctionPointer("vkGetSwapchainCounterEXT");
+            vkGetPhysicalDeviceSurfaceCapabilities2EXT_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDeviceSurfaceCapabilities2EXT");
+            vkEnumeratePhysicalDeviceGroupsKHX_ptr = s_nativeLib.LoadFunctionPointer("vkEnumeratePhysicalDeviceGroupsKHX");
+            vkGetDeviceGroupPeerMemoryFeaturesKHX_ptr = s_nativeLib.LoadFunctionPointer("vkGetDeviceGroupPeerMemoryFeaturesKHX");
+            vkBindBufferMemory2KHX_ptr = s_nativeLib.LoadFunctionPointer("vkBindBufferMemory2KHX");
+            vkBindImageMemory2KHX_ptr = s_nativeLib.LoadFunctionPointer("vkBindImageMemory2KHX");
+            vkCmdSetDeviceMaskKHX_ptr = s_nativeLib.LoadFunctionPointer("vkCmdSetDeviceMaskKHX");
+            vkGetDeviceGroupPresentCapabilitiesKHX_ptr = s_nativeLib.LoadFunctionPointer("vkGetDeviceGroupPresentCapabilitiesKHX");
+            vkGetDeviceGroupSurfacePresentModesKHX_ptr = s_nativeLib.LoadFunctionPointer("vkGetDeviceGroupSurfacePresentModesKHX");
+            vkAcquireNextImage2KHX_ptr = s_nativeLib.LoadFunctionPointer("vkAcquireNextImage2KHX");
+            vkCmdDispatchBaseKHX_ptr = s_nativeLib.LoadFunctionPointer("vkCmdDispatchBaseKHX");
+            vkGetPhysicalDevicePresentRectanglesKHX_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDevicePresentRectanglesKHX");
+            vkCreateDescriptorUpdateTemplateKHR_ptr = s_nativeLib.LoadFunctionPointer("vkCreateDescriptorUpdateTemplateKHR");
+            vkDestroyDescriptorUpdateTemplateKHR_ptr = s_nativeLib.LoadFunctionPointer("vkDestroyDescriptorUpdateTemplateKHR");
+            vkUpdateDescriptorSetWithTemplateKHR_ptr = s_nativeLib.LoadFunctionPointer("vkUpdateDescriptorSetWithTemplateKHR");
+            vkCmdPushDescriptorSetWithTemplateKHR_ptr = s_nativeLib.LoadFunctionPointer("vkCmdPushDescriptorSetWithTemplateKHR");
+            vkSetHdrMetadataEXT_ptr = s_nativeLib.LoadFunctionPointer("vkSetHdrMetadataEXT");
+            vkGetSwapchainStatusKHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetSwapchainStatusKHR");
+            vkGetRefreshCycleDurationGOOGLE_ptr = s_nativeLib.LoadFunctionPointer("vkGetRefreshCycleDurationGOOGLE");
+            vkGetPastPresentationTimingGOOGLE_ptr = s_nativeLib.LoadFunctionPointer("vkGetPastPresentationTimingGOOGLE");
+            vkCreateIOSSurfaceMVK_ptr = s_nativeLib.LoadFunctionPointer("vkCreateIOSSurfaceMVK");
+            vkCreateMacOSSurfaceMVK_ptr = s_nativeLib.LoadFunctionPointer("vkCreateMacOSSurfaceMVK");
+            vkCmdSetViewportWScalingNV_ptr = s_nativeLib.LoadFunctionPointer("vkCmdSetViewportWScalingNV");
+            vkCmdSetDiscardRectangleEXT_ptr = s_nativeLib.LoadFunctionPointer("vkCmdSetDiscardRectangleEXT");
+            vkGetPhysicalDeviceSurfaceCapabilities2KHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDeviceSurfaceCapabilities2KHR");
+            vkGetPhysicalDeviceSurfaceFormats2KHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetPhysicalDeviceSurfaceFormats2KHR");
+            vkGetBufferMemoryRequirements2KHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetBufferMemoryRequirements2KHR");
+            vkGetImageMemoryRequirements2KHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetImageMemoryRequirements2KHR");
+            vkGetImageSparseMemoryRequirements2KHR_ptr = s_nativeLib.LoadFunctionPointer("vkGetImageSparseMemoryRequirements2KHR");
         }
     }
 }

--- a/src/vk/Generated/Constants.gen.cs
+++ b/src/vk/Generated/Constants.gen.cs
@@ -8,9 +8,11 @@ namespace Vulkan
     {
         public const uint MaxPhysicalDeviceNameSize = 256;
         public const uint UuidSize = 16;
+        public const uint LuidSize = 8;
         public const uint MaxExtensionNameSize = 256;
         public const uint MaxDescriptionSize = 256;
         public const uint MaxMemoryTypes = 32;
+        ///<summary>The maximum number of unique memory heaps, each of which supporting 1 or more memory types</summary>
         public const uint MaxMemoryHeaps = 16;
         public const float LodClampNone = 1000.0f;
         public const uint RemainingMipLevels = (~0U);
@@ -20,16 +22,20 @@ namespace Vulkan
         public const uint True = 1;
         public const uint False = 0;
         public const uint QueueFamilyIgnored = (~0U);
+        public const uint QueueFamilyExternal = (~0U-1);
         public const uint SubpassExternal = (~0U);
+        public const uint MaxDeviceGroupSizeKhx = 32;
     }
 
     public static partial class RawConstants
     {
         public const uint VK_MAX_PHYSICAL_DEVICE_NAME_SIZE = VulkanNative.MaxPhysicalDeviceNameSize;
         public const uint VK_UUID_SIZE = VulkanNative.UuidSize;
+        public const uint VK_LUID_SIZE_KHR = VulkanNative.LuidSize;
         public const uint VK_MAX_EXTENSION_NAME_SIZE = VulkanNative.MaxExtensionNameSize;
         public const uint VK_MAX_DESCRIPTION_SIZE = VulkanNative.MaxDescriptionSize;
         public const uint VK_MAX_MEMORY_TYPES = VulkanNative.MaxMemoryTypes;
+        ///<summary>The maximum number of unique memory heaps, each of which supporting 1 or more memory types</summary>
         public const uint VK_MAX_MEMORY_HEAPS = VulkanNative.MaxMemoryHeaps;
         public const float VK_LOD_CLAMP_NONE = VulkanNative.LodClampNone;
         public const uint VK_REMAINING_MIP_LEVELS = VulkanNative.RemainingMipLevels;
@@ -39,6 +45,8 @@ namespace Vulkan
         public const uint VK_TRUE = VulkanNative.True;
         public const uint VK_FALSE = VulkanNative.False;
         public const uint VK_QUEUE_FAMILY_IGNORED = VulkanNative.QueueFamilyIgnored;
+        public const uint VK_QUEUE_FAMILY_EXTERNAL_KHR = VulkanNative.QueueFamilyExternal;
         public const uint VK_SUBPASS_EXTERNAL = VulkanNative.SubpassExternal;
+        public const uint VK_MAX_DEVICE_GROUP_SIZE_KHX = VulkanNative.MaxDeviceGroupSizeKhx;
     }
 }

--- a/src/vk/Generated/Enums.gen.cs
+++ b/src/vk/Generated/Enums.gen.cs
@@ -25,6 +25,7 @@ namespace Vulkan
         ///<summary>Initial layout used when the data is populated by the CPU</summary>
         Preinitialized = 8,
         PresentSrc = 1000001002,
+        SharedPresent = 1000111000,
     }
     public static partial class RawConstants
     {
@@ -47,6 +48,7 @@ namespace Vulkan
         ///<summary>Initial layout used when the data is populated by the CPU</summary>
         public const VkImageLayout VK_IMAGE_LAYOUT_PREINITIALIZED = VkImageLayout.Preinitialized;
         public const VkImageLayout VK_IMAGE_LAYOUT_PRESENT_SRC_KHR = VkImageLayout.PresentSrc;
+        public const VkImageLayout VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR = VkImageLayout.SharedPresent;
     }
 
     public enum VkAttachmentLoadOp
@@ -357,12 +359,14 @@ namespace Vulkan
         Fill = 0,
         Line = 1,
         Point = 2,
+        FillRectangle = 1000153000,
     }
     public static partial class RawConstants
     {
         public const VkPolygonMode VK_POLYGON_MODE_FILL = VkPolygonMode.Fill;
         public const VkPolygonMode VK_POLYGON_MODE_LINE = VkPolygonMode.Line;
         public const VkPolygonMode VK_POLYGON_MODE_POINT = VkPolygonMode.Point;
+        public const VkPolygonMode VK_POLYGON_MODE_FILL_RECTANGLE_NV = VkPolygonMode.FillRectangle;
     }
 
     [Flags]
@@ -444,6 +448,52 @@ namespace Vulkan
         ReverseSubtract = 2,
         Min = 3,
         Max = 4,
+        Zero = 1000148000,
+        Src = 1000148001,
+        Dst = 1000148002,
+        SrcOver = 1000148003,
+        DstOver = 1000148004,
+        SrcIn = 1000148005,
+        DstIn = 1000148006,
+        SrcOut = 1000148007,
+        DstOut = 1000148008,
+        SrcAtop = 1000148009,
+        DstAtop = 1000148010,
+        Xor = 1000148011,
+        Multiply = 1000148012,
+        Screen = 1000148013,
+        Overlay = 1000148014,
+        Darken = 1000148015,
+        Lighten = 1000148016,
+        Colordodge = 1000148017,
+        Colorburn = 1000148018,
+        Hardlight = 1000148019,
+        Softlight = 1000148020,
+        Difference = 1000148021,
+        Exclusion = 1000148022,
+        Invert = 1000148023,
+        InvertRgb = 1000148024,
+        Lineardodge = 1000148025,
+        Linearburn = 1000148026,
+        Vividlight = 1000148027,
+        Linearlight = 1000148028,
+        Pinlight = 1000148029,
+        Hardmix = 1000148030,
+        HslHue = 1000148031,
+        HslSaturation = 1000148032,
+        HslColor = 1000148033,
+        HslLuminosity = 1000148034,
+        Plus = 1000148035,
+        PlusClamped = 1000148036,
+        PlusClampedAlpha = 1000148037,
+        PlusDarker = 1000148038,
+        Minus = 1000148039,
+        MinusClamped = 1000148040,
+        Contrast = 1000148041,
+        InvertOvg = 1000148042,
+        Red = 1000148043,
+        Green = 1000148044,
+        Blue = 1000148045,
     }
     public static partial class RawConstants
     {
@@ -452,6 +502,52 @@ namespace Vulkan
         public const VkBlendOp VK_BLEND_OP_REVERSE_SUBTRACT = VkBlendOp.ReverseSubtract;
         public const VkBlendOp VK_BLEND_OP_MIN = VkBlendOp.Min;
         public const VkBlendOp VK_BLEND_OP_MAX = VkBlendOp.Max;
+        public const VkBlendOp VK_BLEND_OP_ZERO_EXT = VkBlendOp.Zero;
+        public const VkBlendOp VK_BLEND_OP_SRC_EXT = VkBlendOp.Src;
+        public const VkBlendOp VK_BLEND_OP_DST_EXT = VkBlendOp.Dst;
+        public const VkBlendOp VK_BLEND_OP_SRC_OVER_EXT = VkBlendOp.SrcOver;
+        public const VkBlendOp VK_BLEND_OP_DST_OVER_EXT = VkBlendOp.DstOver;
+        public const VkBlendOp VK_BLEND_OP_SRC_IN_EXT = VkBlendOp.SrcIn;
+        public const VkBlendOp VK_BLEND_OP_DST_IN_EXT = VkBlendOp.DstIn;
+        public const VkBlendOp VK_BLEND_OP_SRC_OUT_EXT = VkBlendOp.SrcOut;
+        public const VkBlendOp VK_BLEND_OP_DST_OUT_EXT = VkBlendOp.DstOut;
+        public const VkBlendOp VK_BLEND_OP_SRC_ATOP_EXT = VkBlendOp.SrcAtop;
+        public const VkBlendOp VK_BLEND_OP_DST_ATOP_EXT = VkBlendOp.DstAtop;
+        public const VkBlendOp VK_BLEND_OP_XOR_EXT = VkBlendOp.Xor;
+        public const VkBlendOp VK_BLEND_OP_MULTIPLY_EXT = VkBlendOp.Multiply;
+        public const VkBlendOp VK_BLEND_OP_SCREEN_EXT = VkBlendOp.Screen;
+        public const VkBlendOp VK_BLEND_OP_OVERLAY_EXT = VkBlendOp.Overlay;
+        public const VkBlendOp VK_BLEND_OP_DARKEN_EXT = VkBlendOp.Darken;
+        public const VkBlendOp VK_BLEND_OP_LIGHTEN_EXT = VkBlendOp.Lighten;
+        public const VkBlendOp VK_BLEND_OP_COLORDODGE_EXT = VkBlendOp.Colordodge;
+        public const VkBlendOp VK_BLEND_OP_COLORBURN_EXT = VkBlendOp.Colorburn;
+        public const VkBlendOp VK_BLEND_OP_HARDLIGHT_EXT = VkBlendOp.Hardlight;
+        public const VkBlendOp VK_BLEND_OP_SOFTLIGHT_EXT = VkBlendOp.Softlight;
+        public const VkBlendOp VK_BLEND_OP_DIFFERENCE_EXT = VkBlendOp.Difference;
+        public const VkBlendOp VK_BLEND_OP_EXCLUSION_EXT = VkBlendOp.Exclusion;
+        public const VkBlendOp VK_BLEND_OP_INVERT_EXT = VkBlendOp.Invert;
+        public const VkBlendOp VK_BLEND_OP_INVERT_RGB_EXT = VkBlendOp.InvertRgb;
+        public const VkBlendOp VK_BLEND_OP_LINEARDODGE_EXT = VkBlendOp.Lineardodge;
+        public const VkBlendOp VK_BLEND_OP_LINEARBURN_EXT = VkBlendOp.Linearburn;
+        public const VkBlendOp VK_BLEND_OP_VIVIDLIGHT_EXT = VkBlendOp.Vividlight;
+        public const VkBlendOp VK_BLEND_OP_LINEARLIGHT_EXT = VkBlendOp.Linearlight;
+        public const VkBlendOp VK_BLEND_OP_PINLIGHT_EXT = VkBlendOp.Pinlight;
+        public const VkBlendOp VK_BLEND_OP_HARDMIX_EXT = VkBlendOp.Hardmix;
+        public const VkBlendOp VK_BLEND_OP_HSL_HUE_EXT = VkBlendOp.HslHue;
+        public const VkBlendOp VK_BLEND_OP_HSL_SATURATION_EXT = VkBlendOp.HslSaturation;
+        public const VkBlendOp VK_BLEND_OP_HSL_COLOR_EXT = VkBlendOp.HslColor;
+        public const VkBlendOp VK_BLEND_OP_HSL_LUMINOSITY_EXT = VkBlendOp.HslLuminosity;
+        public const VkBlendOp VK_BLEND_OP_PLUS_EXT = VkBlendOp.Plus;
+        public const VkBlendOp VK_BLEND_OP_PLUS_CLAMPED_EXT = VkBlendOp.PlusClamped;
+        public const VkBlendOp VK_BLEND_OP_PLUS_CLAMPED_ALPHA_EXT = VkBlendOp.PlusClampedAlpha;
+        public const VkBlendOp VK_BLEND_OP_PLUS_DARKER_EXT = VkBlendOp.PlusDarker;
+        public const VkBlendOp VK_BLEND_OP_MINUS_EXT = VkBlendOp.Minus;
+        public const VkBlendOp VK_BLEND_OP_MINUS_CLAMPED_EXT = VkBlendOp.MinusClamped;
+        public const VkBlendOp VK_BLEND_OP_CONTRAST_EXT = VkBlendOp.Contrast;
+        public const VkBlendOp VK_BLEND_OP_INVERT_OVG_EXT = VkBlendOp.InvertOvg;
+        public const VkBlendOp VK_BLEND_OP_RED_EXT = VkBlendOp.Red;
+        public const VkBlendOp VK_BLEND_OP_GREEN_EXT = VkBlendOp.Green;
+        public const VkBlendOp VK_BLEND_OP_BLUE_EXT = VkBlendOp.Blue;
     }
 
     public enum VkStencilOp
@@ -1012,7 +1108,9 @@ namespace Vulkan
         BufferMemoryBarrier = 44,
         ImageMemoryBarrier = 45,
         MemoryBarrier = 46,
+        ///<summary>Reserved for internal use by the loader, layers, and ICDs</summary>
         LoaderInstanceCreateInfo = 47,
+        ///<summary>Reserved for internal use by the loader, layers, and ICDs</summary>
         LoaderDeviceCreateInfo = 48,
         SwapchainCreateInfo = 1000001000,
         PresentInfo = 1000001001,
@@ -1033,18 +1131,117 @@ namespace Vulkan
         DedicatedAllocationImageCreateInfo = 1000026000,
         DedicatedAllocationBufferCreateInfo = 1000026001,
         DedicatedAllocationMemoryAllocateInfo = 1000026002,
-        ExternalMemoryImageCreateInfo = 1000056000,
-        ExportMemoryAllocateInfo = 1000056001,
-        ImportMemoryWin32HandleInfo = 1000057000,
-        ExportMemoryWin32HandleInfo = 1000057001,
-        Win32KeyedMutexAcquireReleaseInfo = 1000058000,
+        TextureLodGatherFormatProperties = 1000041000,
+        RenderPassMultiviewCreateInfoKhx = 1000053000,
+        PhysicalDeviceMultiviewFeaturesKhx = 1000053001,
+        PhysicalDeviceMultiviewPropertiesKhx = 1000053002,
+        ExportMemoryImageCreateInfoNV = 1000056000,
+        ExportMemoryAllocateInfoNV = 1000056001,
+        ImportMemoryWin32HandleInfoNV = 1000057000,
+        ExportMemoryWin32HandleInfoNV = 1000057001,
+        Win32KeyedMutexAcquireReleaseInfoNV = 1000058000,
+        PhysicalDeviceFeatures2 = 1000059000,
+        PhysicalDeviceProperties2 = 1000059001,
+        FormatProperties2 = 1000059002,
+        ImageFormatProperties2 = 1000059003,
+        PhysicalDeviceImageFormatInfo2 = 1000059004,
+        QueueFamilyProperties2 = 1000059005,
+        PhysicalDeviceMemoryProperties2 = 1000059006,
+        SparseImageFormatProperties2 = 1000059007,
+        PhysicalDeviceSparseImageFormatInfo2 = 1000059008,
+        MemoryAllocateInfoKhx = 1000060000,
+        BindBufferMemoryInfoKhx = 1000060001,
+        BindImageMemoryInfoKhx = 1000060002,
+        DeviceGroupRenderPassBeginInfoKhx = 1000060003,
+        DeviceGroupCommandBufferBeginInfoKhx = 1000060004,
+        DeviceGroupSubmitInfoKhx = 1000060005,
+        DeviceGroupBindSparseInfoKhx = 1000060006,
+        DeviceGroupPresentCapabilitiesKhx = 1000060007,
+        ImageSwapchainCreateInfoKhx = 1000060008,
+        BindImageMemorySwapchainInfoKhx = 1000060009,
+        AcquireNextImageInfoKhx = 1000060010,
+        DeviceGroupPresentInfoKhx = 1000060011,
+        DeviceGroupSwapchainCreateInfoKhx = 1000060012,
         Validation = 1000061000,
+        ViSurfaceCreateInfoNn = 1000062000,
+        PhysicalDeviceGroupPropertiesKhx = 1000070000,
+        DeviceGroupDeviceCreateInfoKhx = 1000070001,
+        PhysicalDeviceExternalImageFormatInfo = 1000071000,
+        ExternalImageFormatProperties = 1000071001,
+        PhysicalDeviceExternalBufferInfo = 1000071002,
+        ExternalBufferProperties = 1000071003,
+        PhysicalDeviceIdProperties = 1000071004,
+        ExternalMemoryBufferCreateInfo = 1000072000,
+        ExportMemoryImageCreateInfoKHR = 1000072001,
+        ExportMemoryAllocateInfoKHR = 1000072002,
+        ImportMemoryWin32HandleInfoKHR = 1000073000,
+        ExportMemoryWin32HandleInfoKHR = 1000073001,
+        MemoryWin32HandleProperties = 1000073002,
+        MemoryGetWin32HandleInfo = 1000073003,
+        ImportMemoryFdInfo = 1000074000,
+        MemoryFdProperties = 1000074001,
+        MemoryGetFdInfo = 1000074002,
+        Win32KeyedMutexAcquireReleaseInfo = 1000075000,
+        PhysicalDeviceExternalSemaphoreInfo = 1000076000,
+        ExternalSemaphoreProperties = 1000076001,
+        ExportSemaphoreCreateInfo = 1000077000,
+        ImportSemaphoreWin32HandleInfo = 1000078000,
+        ExportSemaphoreWin32HandleInfo = 1000078001,
+        D3d12FenceSubmitInfo = 1000078002,
+        SemaphoreGetWin32HandleInfo = 1000078003,
+        ImportSemaphoreFdInfo = 1000079000,
+        SemaphoreGetFdInfo = 1000079001,
+        PhysicalDevicePushDescriptorProperties = 1000080000,
+        PhysicalDevice16bitStorageFeatures = 1000083000,
+        PresentRegions = 1000084000,
+        DescriptorUpdateTemplateCreateInfo = 1000085000,
         ObjectTableCreateInfo = 1000086000,
         IndirectCommandsLayoutCreateInfo = 1000086001,
         CmdProcessCommandsInfo = 1000086002,
         CmdReserveSpaceForCommandsInfo = 1000086003,
         DeviceGeneratedCommandsLimits = 1000086004,
         DeviceGeneratedCommandsFeatures = 1000086005,
+        PipelineViewportWScalingStateCreateInfo = 1000087000,
+        SurfaceCapabilities2Ext = 1000090000,
+        DisplayPowerInfo = 1000091000,
+        DeviceEventInfo = 1000091001,
+        DisplayEventInfo = 1000091002,
+        SwapchainCounterCreateInfo = 1000091003,
+        PresentTimesInfoGoogle = 1000092000,
+        PhysicalDeviceMultiviewPerViewAttributesProperties = 1000097000,
+        PipelineViewportSwizzleStateCreateInfo = 1000098000,
+        PhysicalDeviceDiscardRectangleProperties = 1000099000,
+        PipelineDiscardRectangleStateCreateInfo = 1000099001,
+        HdrMetadata = 1000105000,
+        SharedPresentSurfaceCapabilities = 1000111000,
+        PhysicalDeviceExternalFenceInfo = 1000112000,
+        ExternalFenceProperties = 1000112001,
+        ExportFenceCreateInfo = 1000113000,
+        ImportFenceWin32HandleInfo = 1000114000,
+        ExportFenceWin32HandleInfo = 1000114001,
+        FenceGetWin32HandleInfo = 1000114002,
+        ImportFenceFdInfo = 1000115000,
+        FenceGetFdInfo = 1000115001,
+        PhysicalDeviceSurfaceInfo2 = 1000119000,
+        SurfaceCapabilities2Khr = 1000119001,
+        SurfaceFormat2 = 1000119002,
+        PhysicalDeviceVariablePointerFeatures = 1000120000,
+        IosSurfaceCreateInfoMvk = 1000122000,
+        MacosSurfaceCreateInfoMvk = 1000123000,
+        MemoryDedicatedRequirements = 1000127000,
+        MemoryDedicatedAllocateInfo = 1000127001,
+        PhysicalDeviceSamplerFilterMinmaxProperties = 1000130000,
+        SamplerReductionModeCreateInfo = 1000130001,
+        BufferMemoryRequirementsInfo2 = 1000146000,
+        ImageMemoryRequirementsInfo2 = 1000146001,
+        ImageSparseMemoryRequirementsInfo2 = 1000146002,
+        MemoryRequirements2 = 1000146003,
+        SparseImageMemoryRequirements2 = 1000146004,
+        PhysicalDeviceBlendOperationAdvancedFeatures = 1000148000,
+        PhysicalDeviceBlendOperationAdvancedProperties = 1000148001,
+        PipelineColorBlendAdvancedStateCreateInfo = 1000148002,
+        PipelineCoverageToColorStateCreateInfo = 1000149000,
+        PipelineCoverageModulationStateCreateInfo = 1000152000,
     }
     public static partial class RawConstants
     {
@@ -1095,7 +1292,9 @@ namespace Vulkan
         public const VkStructureType VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER = VkStructureType.BufferMemoryBarrier;
         public const VkStructureType VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER = VkStructureType.ImageMemoryBarrier;
         public const VkStructureType VK_STRUCTURE_TYPE_MEMORY_BARRIER = VkStructureType.MemoryBarrier;
+        ///<summary>Reserved for internal use by the loader, layers, and ICDs</summary>
         public const VkStructureType VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO = VkStructureType.LoaderInstanceCreateInfo;
+        ///<summary>Reserved for internal use by the loader, layers, and ICDs</summary>
         public const VkStructureType VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO = VkStructureType.LoaderDeviceCreateInfo;
         public const VkStructureType VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR = VkStructureType.SwapchainCreateInfo;
         public const VkStructureType VK_STRUCTURE_TYPE_PRESENT_INFO_KHR = VkStructureType.PresentInfo;
@@ -1116,18 +1315,117 @@ namespace Vulkan
         public const VkStructureType VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV = VkStructureType.DedicatedAllocationImageCreateInfo;
         public const VkStructureType VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV = VkStructureType.DedicatedAllocationBufferCreateInfo;
         public const VkStructureType VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV = VkStructureType.DedicatedAllocationMemoryAllocateInfo;
-        public const VkStructureType VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV = VkStructureType.ExternalMemoryImageCreateInfo;
-        public const VkStructureType VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_NV = VkStructureType.ExportMemoryAllocateInfo;
-        public const VkStructureType VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_NV = VkStructureType.ImportMemoryWin32HandleInfo;
-        public const VkStructureType VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_NV = VkStructureType.ExportMemoryWin32HandleInfo;
-        public const VkStructureType VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV = VkStructureType.Win32KeyedMutexAcquireReleaseInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD = VkStructureType.TextureLodGatherFormatProperties;
+        public const VkStructureType VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO_KHX = VkStructureType.RenderPassMultiviewCreateInfoKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHX = VkStructureType.PhysicalDeviceMultiviewFeaturesKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES_KHX = VkStructureType.PhysicalDeviceMultiviewPropertiesKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV = VkStructureType.ExportMemoryImageCreateInfoNV;
+        public const VkStructureType VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_NV = VkStructureType.ExportMemoryAllocateInfoNV;
+        public const VkStructureType VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_NV = VkStructureType.ImportMemoryWin32HandleInfoNV;
+        public const VkStructureType VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_NV = VkStructureType.ExportMemoryWin32HandleInfoNV;
+        public const VkStructureType VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV = VkStructureType.Win32KeyedMutexAcquireReleaseInfoNV;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR = VkStructureType.PhysicalDeviceFeatures2;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR = VkStructureType.PhysicalDeviceProperties2;
+        public const VkStructureType VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR = VkStructureType.FormatProperties2;
+        public const VkStructureType VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2_KHR = VkStructureType.ImageFormatProperties2;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2_KHR = VkStructureType.PhysicalDeviceImageFormatInfo2;
+        public const VkStructureType VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2_KHR = VkStructureType.QueueFamilyProperties2;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2_KHR = VkStructureType.PhysicalDeviceMemoryProperties2;
+        public const VkStructureType VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2_KHR = VkStructureType.SparseImageFormatProperties2;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2_KHR = VkStructureType.PhysicalDeviceSparseImageFormatInfo2;
+        public const VkStructureType VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO_KHX = VkStructureType.MemoryAllocateInfoKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_INFO_KHX = VkStructureType.BindBufferMemoryInfoKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO_KHX = VkStructureType.BindImageMemoryInfoKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_DEVICE_GROUP_RENDER_PASS_BEGIN_INFO_KHX = VkStructureType.DeviceGroupRenderPassBeginInfoKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_DEVICE_GROUP_COMMAND_BUFFER_BEGIN_INFO_KHX = VkStructureType.DeviceGroupCommandBufferBeginInfoKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_DEVICE_GROUP_SUBMIT_INFO_KHX = VkStructureType.DeviceGroupSubmitInfoKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_DEVICE_GROUP_BIND_SPARSE_INFO_KHX = VkStructureType.DeviceGroupBindSparseInfoKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_CAPABILITIES_KHX = VkStructureType.DeviceGroupPresentCapabilitiesKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_IMAGE_SWAPCHAIN_CREATE_INFO_KHX = VkStructureType.ImageSwapchainCreateInfoKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHX = VkStructureType.BindImageMemorySwapchainInfoKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_ACQUIRE_NEXT_IMAGE_INFO_KHX = VkStructureType.AcquireNextImageInfoKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_INFO_KHX = VkStructureType.DeviceGroupPresentInfoKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_DEVICE_GROUP_SWAPCHAIN_CREATE_INFO_KHX = VkStructureType.DeviceGroupSwapchainCreateInfoKhx;
         public const VkStructureType VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT = VkStructureType.Validation;
+        public const VkStructureType VK_STRUCTURE_TYPE_VI_SURFACE_CREATE_INFO_NN = VkStructureType.ViSurfaceCreateInfoNn;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES_KHX = VkStructureType.PhysicalDeviceGroupPropertiesKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO_KHX = VkStructureType.DeviceGroupDeviceCreateInfoKhx;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO_KHR = VkStructureType.PhysicalDeviceExternalImageFormatInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES_KHR = VkStructureType.ExternalImageFormatProperties;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO_KHR = VkStructureType.PhysicalDeviceExternalBufferInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES_KHR = VkStructureType.ExternalBufferProperties;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES_KHR = VkStructureType.PhysicalDeviceIdProperties;
+        public const VkStructureType VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO_KHR = VkStructureType.ExternalMemoryBufferCreateInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_KHR = VkStructureType.ExportMemoryImageCreateInfoKHR;
+        public const VkStructureType VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR = VkStructureType.ExportMemoryAllocateInfoKHR;
+        public const VkStructureType VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR = VkStructureType.ImportMemoryWin32HandleInfoKHR;
+        public const VkStructureType VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR = VkStructureType.ExportMemoryWin32HandleInfoKHR;
+        public const VkStructureType VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR = VkStructureType.MemoryWin32HandleProperties;
+        public const VkStructureType VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR = VkStructureType.MemoryGetWin32HandleInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR = VkStructureType.ImportMemoryFdInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR = VkStructureType.MemoryFdProperties;
+        public const VkStructureType VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR = VkStructureType.MemoryGetFdInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR = VkStructureType.Win32KeyedMutexAcquireReleaseInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO_KHR = VkStructureType.PhysicalDeviceExternalSemaphoreInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES_KHR = VkStructureType.ExternalSemaphoreProperties;
+        public const VkStructureType VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO_KHR = VkStructureType.ExportSemaphoreCreateInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR = VkStructureType.ImportSemaphoreWin32HandleInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR = VkStructureType.ExportSemaphoreWin32HandleInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR = VkStructureType.D3d12FenceSubmitInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR = VkStructureType.SemaphoreGetWin32HandleInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR = VkStructureType.ImportSemaphoreFdInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR = VkStructureType.SemaphoreGetFdInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR = VkStructureType.PhysicalDevicePushDescriptorProperties;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES_KHR = VkStructureType.PhysicalDevice16bitStorageFeatures;
+        public const VkStructureType VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR = VkStructureType.PresentRegions;
+        public const VkStructureType VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR = VkStructureType.DescriptorUpdateTemplateCreateInfo;
         public const VkStructureType VK_STRUCTURE_TYPE_OBJECT_TABLE_CREATE_INFO_NVX = VkStructureType.ObjectTableCreateInfo;
         public const VkStructureType VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NVX = VkStructureType.IndirectCommandsLayoutCreateInfo;
         public const VkStructureType VK_STRUCTURE_TYPE_CMD_PROCESS_COMMANDS_INFO_NVX = VkStructureType.CmdProcessCommandsInfo;
         public const VkStructureType VK_STRUCTURE_TYPE_CMD_RESERVE_SPACE_FOR_COMMANDS_INFO_NVX = VkStructureType.CmdReserveSpaceForCommandsInfo;
         public const VkStructureType VK_STRUCTURE_TYPE_DEVICE_GENERATED_COMMANDS_LIMITS_NVX = VkStructureType.DeviceGeneratedCommandsLimits;
         public const VkStructureType VK_STRUCTURE_TYPE_DEVICE_GENERATED_COMMANDS_FEATURES_NVX = VkStructureType.DeviceGeneratedCommandsFeatures;
+        public const VkStructureType VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV = VkStructureType.PipelineViewportWScalingStateCreateInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES2_EXT = VkStructureType.SurfaceCapabilities2Ext;
+        public const VkStructureType VK_STRUCTURE_TYPE_DISPLAY_POWER_INFO_EXT = VkStructureType.DisplayPowerInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_DEVICE_EVENT_INFO_EXT = VkStructureType.DeviceEventInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_DISPLAY_EVENT_INFO_EXT = VkStructureType.DisplayEventInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_SWAPCHAIN_COUNTER_CREATE_INFO_EXT = VkStructureType.SwapchainCounterCreateInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE = VkStructureType.PresentTimesInfoGoogle;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX = VkStructureType.PhysicalDeviceMultiviewPerViewAttributesProperties;
+        public const VkStructureType VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV = VkStructureType.PipelineViewportSwizzleStateCreateInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT = VkStructureType.PhysicalDeviceDiscardRectangleProperties;
+        public const VkStructureType VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT = VkStructureType.PipelineDiscardRectangleStateCreateInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_HDR_METADATA_EXT = VkStructureType.HdrMetadata;
+        public const VkStructureType VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR = VkStructureType.SharedPresentSurfaceCapabilities;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO_KHR = VkStructureType.PhysicalDeviceExternalFenceInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES_KHR = VkStructureType.ExternalFenceProperties;
+        public const VkStructureType VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO_KHR = VkStructureType.ExportFenceCreateInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_IMPORT_FENCE_WIN32_HANDLE_INFO_KHR = VkStructureType.ImportFenceWin32HandleInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_EXPORT_FENCE_WIN32_HANDLE_INFO_KHR = VkStructureType.ExportFenceWin32HandleInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_FENCE_GET_WIN32_HANDLE_INFO_KHR = VkStructureType.FenceGetWin32HandleInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_IMPORT_FENCE_FD_INFO_KHR = VkStructureType.ImportFenceFdInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR = VkStructureType.FenceGetFdInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR = VkStructureType.PhysicalDeviceSurfaceInfo2;
+        public const VkStructureType VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR = VkStructureType.SurfaceCapabilities2Khr;
+        public const VkStructureType VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR = VkStructureType.SurfaceFormat2;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES_KHR = VkStructureType.PhysicalDeviceVariablePointerFeatures;
+        public const VkStructureType VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK = VkStructureType.IosSurfaceCreateInfoMvk;
+        public const VkStructureType VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK = VkStructureType.MacosSurfaceCreateInfoMvk;
+        public const VkStructureType VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR = VkStructureType.MemoryDedicatedRequirements;
+        public const VkStructureType VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR = VkStructureType.MemoryDedicatedAllocateInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES_EXT = VkStructureType.PhysicalDeviceSamplerFilterMinmaxProperties;
+        public const VkStructureType VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT = VkStructureType.SamplerReductionModeCreateInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2_KHR = VkStructureType.BufferMemoryRequirementsInfo2;
+        public const VkStructureType VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2_KHR = VkStructureType.ImageMemoryRequirementsInfo2;
+        public const VkStructureType VK_STRUCTURE_TYPE_IMAGE_SPARSE_MEMORY_REQUIREMENTS_INFO_2_KHR = VkStructureType.ImageSparseMemoryRequirementsInfo2;
+        public const VkStructureType VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR = VkStructureType.MemoryRequirements2;
+        public const VkStructureType VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2_KHR = VkStructureType.SparseImageMemoryRequirements2;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT = VkStructureType.PhysicalDeviceBlendOperationAdvancedFeatures;
+        public const VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT = VkStructureType.PhysicalDeviceBlendOperationAdvancedProperties;
+        public const VkStructureType VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT = VkStructureType.PipelineColorBlendAdvancedStateCreateInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_TO_COLOR_STATE_CREATE_INFO_NV = VkStructureType.PipelineCoverageToColorStateCreateInfo;
+        public const VkStructureType VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV = VkStructureType.PipelineCoverageModulationStateCreateInfo;
     }
 
     public enum VkSubpassContents
@@ -1186,7 +1484,8 @@ namespace Vulkan
         ErrorIncompatibleDisplay = 1000003001,
         ErrorValidationFailed = 1000011001,
         ErrorInvalidShader = 1000012000,
-        Extension1Error = 1000013000,
+        ErrorOutOfPoolMemory = 1000069000,
+        ErrorInvalidExternalHandle = 1000072003,
     }
     public static partial class RawConstants
     {
@@ -1233,7 +1532,8 @@ namespace Vulkan
         public const VkResult VK_ERROR_INCOMPATIBLE_DISPLAY_KHR = VkResult.ErrorIncompatibleDisplay;
         public const VkResult VK_ERROR_VALIDATION_FAILED_EXT = VkResult.ErrorValidationFailed;
         public const VkResult VK_ERROR_INVALID_SHADER_NV = VkResult.ErrorInvalidShader;
-        public const VkResult VK_NV_EXTENSION_1_ERROR = VkResult.Extension1Error;
+        public const VkResult VK_ERROR_OUT_OF_POOL_MEMORY_KHR = VkResult.ErrorOutOfPoolMemory;
+        public const VkResult VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR = VkResult.ErrorInvalidExternalHandle;
     }
 
     public enum VkDynamicState
@@ -1247,6 +1547,8 @@ namespace Vulkan
         StencilCompareMask = 6,
         StencilWriteMask = 7,
         StencilReference = 8,
+        ViewportWScaling = 1000087000,
+        DiscardRectangle = 1000099000,
     }
     public static partial class RawConstants
     {
@@ -1259,6 +1561,148 @@ namespace Vulkan
         public const VkDynamicState VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK = VkDynamicState.StencilCompareMask;
         public const VkDynamicState VK_DYNAMIC_STATE_STENCIL_WRITE_MASK = VkDynamicState.StencilWriteMask;
         public const VkDynamicState VK_DYNAMIC_STATE_STENCIL_REFERENCE = VkDynamicState.StencilReference;
+        public const VkDynamicState VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV = VkDynamicState.ViewportWScaling;
+        public const VkDynamicState VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT = VkDynamicState.DiscardRectangle;
+    }
+
+    public enum VkDescriptorUpdateTemplateTypeKHR
+    {
+        ///<summary>Create descriptor update template for descriptor set updates</summary>
+        DescriptorSet = 0,
+        ///<summary>Create descriptor update template for pushed descriptor updates</summary>
+        PushDescriptors = 1,
+    }
+    public static partial class RawConstants
+    {
+        ///<summary>Create descriptor update template for descriptor set updates</summary>
+        public const VkDescriptorUpdateTemplateTypeKHR VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET_KHR = VkDescriptorUpdateTemplateTypeKHR.DescriptorSet;
+        ///<summary>Create descriptor update template for pushed descriptor updates</summary>
+        public const VkDescriptorUpdateTemplateTypeKHR VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR = VkDescriptorUpdateTemplateTypeKHR.PushDescriptors;
+    }
+
+    public enum VkObjectType
+    {
+        Unknown = 0,
+        ///<summary>VkInstance</summary>
+        Instance = 1,
+        ///<summary>VkPhysicalDevice</summary>
+        PhysicalDevice = 2,
+        ///<summary>VkDevice</summary>
+        Device = 3,
+        ///<summary>VkQueue</summary>
+        Queue = 4,
+        ///<summary>VkSemaphore</summary>
+        Semaphore = 5,
+        ///<summary>VkCommandBuffer</summary>
+        CommandBuffer = 6,
+        ///<summary>VkFence</summary>
+        Fence = 7,
+        ///<summary>VkDeviceMemory</summary>
+        DeviceMemory = 8,
+        ///<summary>VkBuffer</summary>
+        Buffer = 9,
+        ///<summary>VkImage</summary>
+        Image = 10,
+        ///<summary>VkEvent</summary>
+        Event = 11,
+        ///<summary>VkQueryPool</summary>
+        QueryPool = 12,
+        ///<summary>VkBufferView</summary>
+        BufferView = 13,
+        ///<summary>VkImageView</summary>
+        ImageView = 14,
+        ///<summary>VkShaderModule</summary>
+        ShaderModule = 15,
+        ///<summary>VkPipelineCache</summary>
+        PipelineCache = 16,
+        ///<summary>VkPipelineLayout</summary>
+        PipelineLayout = 17,
+        ///<summary>VkRenderPass</summary>
+        RenderPass = 18,
+        ///<summary>VkPipeline</summary>
+        Pipeline = 19,
+        ///<summary>VkDescriptorSetLayout</summary>
+        DescriptorSetLayout = 20,
+        ///<summary>VkSampler</summary>
+        Sampler = 21,
+        ///<summary>VkDescriptorPool</summary>
+        DescriptorPool = 22,
+        ///<summary>VkDescriptorSet</summary>
+        DescriptorSet = 23,
+        ///<summary>VkFramebuffer</summary>
+        Framebuffer = 24,
+        ///<summary>VkCommandPool</summary>
+        CommandPool = 25,
+        Surface = 1000000000,
+        Swapchain = 1000001000,
+        Display = 1000002000,
+        DisplayMode = 1000002001,
+        DebugReportCallback = 1000011000,
+        DescriptorUpdateTemplate = 1000085000,
+        ObjectTable = 1000086000,
+        IndirectCommandsLayout = 1000086001,
+    }
+    public static partial class RawConstants
+    {
+        public const VkObjectType VK_OBJECT_TYPE_UNKNOWN = VkObjectType.Unknown;
+        ///<summary>VkInstance</summary>
+        public const VkObjectType VK_OBJECT_TYPE_INSTANCE = VkObjectType.Instance;
+        ///<summary>VkPhysicalDevice</summary>
+        public const VkObjectType VK_OBJECT_TYPE_PHYSICAL_DEVICE = VkObjectType.PhysicalDevice;
+        ///<summary>VkDevice</summary>
+        public const VkObjectType VK_OBJECT_TYPE_DEVICE = VkObjectType.Device;
+        ///<summary>VkQueue</summary>
+        public const VkObjectType VK_OBJECT_TYPE_QUEUE = VkObjectType.Queue;
+        ///<summary>VkSemaphore</summary>
+        public const VkObjectType VK_OBJECT_TYPE_SEMAPHORE = VkObjectType.Semaphore;
+        ///<summary>VkCommandBuffer</summary>
+        public const VkObjectType VK_OBJECT_TYPE_COMMAND_BUFFER = VkObjectType.CommandBuffer;
+        ///<summary>VkFence</summary>
+        public const VkObjectType VK_OBJECT_TYPE_FENCE = VkObjectType.Fence;
+        ///<summary>VkDeviceMemory</summary>
+        public const VkObjectType VK_OBJECT_TYPE_DEVICE_MEMORY = VkObjectType.DeviceMemory;
+        ///<summary>VkBuffer</summary>
+        public const VkObjectType VK_OBJECT_TYPE_BUFFER = VkObjectType.Buffer;
+        ///<summary>VkImage</summary>
+        public const VkObjectType VK_OBJECT_TYPE_IMAGE = VkObjectType.Image;
+        ///<summary>VkEvent</summary>
+        public const VkObjectType VK_OBJECT_TYPE_EVENT = VkObjectType.Event;
+        ///<summary>VkQueryPool</summary>
+        public const VkObjectType VK_OBJECT_TYPE_QUERY_POOL = VkObjectType.QueryPool;
+        ///<summary>VkBufferView</summary>
+        public const VkObjectType VK_OBJECT_TYPE_BUFFER_VIEW = VkObjectType.BufferView;
+        ///<summary>VkImageView</summary>
+        public const VkObjectType VK_OBJECT_TYPE_IMAGE_VIEW = VkObjectType.ImageView;
+        ///<summary>VkShaderModule</summary>
+        public const VkObjectType VK_OBJECT_TYPE_SHADER_MODULE = VkObjectType.ShaderModule;
+        ///<summary>VkPipelineCache</summary>
+        public const VkObjectType VK_OBJECT_TYPE_PIPELINE_CACHE = VkObjectType.PipelineCache;
+        ///<summary>VkPipelineLayout</summary>
+        public const VkObjectType VK_OBJECT_TYPE_PIPELINE_LAYOUT = VkObjectType.PipelineLayout;
+        ///<summary>VkRenderPass</summary>
+        public const VkObjectType VK_OBJECT_TYPE_RENDER_PASS = VkObjectType.RenderPass;
+        ///<summary>VkPipeline</summary>
+        public const VkObjectType VK_OBJECT_TYPE_PIPELINE = VkObjectType.Pipeline;
+        ///<summary>VkDescriptorSetLayout</summary>
+        public const VkObjectType VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT = VkObjectType.DescriptorSetLayout;
+        ///<summary>VkSampler</summary>
+        public const VkObjectType VK_OBJECT_TYPE_SAMPLER = VkObjectType.Sampler;
+        ///<summary>VkDescriptorPool</summary>
+        public const VkObjectType VK_OBJECT_TYPE_DESCRIPTOR_POOL = VkObjectType.DescriptorPool;
+        ///<summary>VkDescriptorSet</summary>
+        public const VkObjectType VK_OBJECT_TYPE_DESCRIPTOR_SET = VkObjectType.DescriptorSet;
+        ///<summary>VkFramebuffer</summary>
+        public const VkObjectType VK_OBJECT_TYPE_FRAMEBUFFER = VkObjectType.Framebuffer;
+        ///<summary>VkCommandPool</summary>
+        public const VkObjectType VK_OBJECT_TYPE_COMMAND_POOL = VkObjectType.CommandPool;
+        public const VkObjectType VK_OBJECT_TYPE_SURFACE_KHR = VkObjectType.Surface;
+        public const VkObjectType VK_OBJECT_TYPE_SWAPCHAIN_KHR = VkObjectType.Swapchain;
+        public const VkObjectType VK_OBJECT_TYPE_DISPLAY_KHR = VkObjectType.Display;
+        public const VkObjectType VK_OBJECT_TYPE_DISPLAY_MODE_KHR = VkObjectType.DisplayMode;
+        public const VkObjectType VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT = VkObjectType.DebugReportCallback;
+        public const VkObjectType VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR = VkObjectType.DescriptorUpdateTemplate;
+        public const VkObjectType VK_OBJECT_TYPE_OBJECT_TABLE_NVX = VkObjectType.ObjectTable;
+        public const VkObjectType VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NVX = VkObjectType.IndirectCommandsLayout;
     }
 
     [Flags]
@@ -1321,11 +1765,13 @@ namespace Vulkan
         None = 0,
         ///<summary>If set, heap represents device memory</summary>
         DeviceLocal = 1,
+        MultiInstanceKhx = 2,
     }
     public static partial class RawConstants
     {
         ///<summary>If set, heap represents device memory</summary>
         public const VkMemoryHeapFlags VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = VkMemoryHeapFlags.DeviceLocal;
+        public const VkMemoryHeapFlags VK_MEMORY_HEAP_MULTI_INSTANCE_BIT_KHX = VkMemoryHeapFlags.MultiInstanceKhx;
     }
 
     [Flags]
@@ -1368,6 +1814,7 @@ namespace Vulkan
         MemoryWrite = 65536,
         CommandProcessRead = 131072,
         CommandProcessWrite = 262144,
+        ColorAttachmentReadNoncoherent = 524288,
     }
     public static partial class RawConstants
     {
@@ -1407,6 +1854,7 @@ namespace Vulkan
         public const VkAccessFlags VK_ACCESS_MEMORY_WRITE_BIT = VkAccessFlags.MemoryWrite;
         public const VkAccessFlags VK_ACCESS_COMMAND_PROCESS_READ_BIT_NVX = VkAccessFlags.CommandProcessRead;
         public const VkAccessFlags VK_ACCESS_COMMAND_PROCESS_WRITE_BIT_NVX = VkAccessFlags.CommandProcessWrite;
+        public const VkAccessFlags VK_ACCESS_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT = VkAccessFlags.ColorAttachmentReadNoncoherent;
     }
 
     [Flags]
@@ -1555,6 +2003,8 @@ namespace Vulkan
         MutableFormat = 8,
         ///<summary>Allows creating image views with cube type from the created image</summary>
         CubeCompatible = 16,
+        BindSfrKhx = 64,
+        _2dArrayCompatible = 32,
     }
     public static partial class RawConstants
     {
@@ -1568,6 +2018,8 @@ namespace Vulkan
         public const VkImageCreateFlags VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT = VkImageCreateFlags.MutableFormat;
         ///<summary>Allows creating image views with cube type from the created image</summary>
         public const VkImageCreateFlags VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT = VkImageCreateFlags.CubeCompatible;
+        public const VkImageCreateFlags VK_IMAGE_CREATE_BIND_SFR_BIT_KHX = VkImageCreateFlags.BindSfrKhx;
+        public const VkImageCreateFlags VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR = VkImageCreateFlags._2dArrayCompatible;
     }
 
     [Flags]
@@ -1577,12 +2029,16 @@ namespace Vulkan
         DisableOptimization = 1,
         AllowDerivatives = 2,
         Derivative = 4,
+        ViewIndexFromDeviceIndexKhx = 8,
+        DispatchBaseKhx = 16,
     }
     public static partial class RawConstants
     {
         public const VkPipelineCreateFlags VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT = VkPipelineCreateFlags.DisableOptimization;
         public const VkPipelineCreateFlags VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT = VkPipelineCreateFlags.AllowDerivatives;
         public const VkPipelineCreateFlags VK_PIPELINE_CREATE_DERIVATIVE_BIT = VkPipelineCreateFlags.Derivative;
+        public const VkPipelineCreateFlags VK_PIPELINE_CREATE_VIEW_INDEX_FROM_DEVICE_INDEX_BIT_KHX = VkPipelineCreateFlags.ViewIndexFromDeviceIndexKhx;
+        public const VkPipelineCreateFlags VK_PIPELINE_CREATE_DISPATCH_BASE_KHX = VkPipelineCreateFlags.DispatchBaseKhx;
     }
 
     [Flags]
@@ -1644,6 +2100,9 @@ namespace Vulkan
         ///<summary>Format can be filtered with VK_FILTER_LINEAR when being sampled</summary>
         SampledImageFilterLinear = 4096,
         SampledImageFilterCubicImg = 8192,
+        TransferSrc = 16384,
+        TransferDst = 32768,
+        SampledImageFilterMinmax = 65536,
     }
     public static partial class RawConstants
     {
@@ -1674,6 +2133,9 @@ namespace Vulkan
         ///<summary>Format can be filtered with VK_FILTER_LINEAR when being sampled</summary>
         public const VkFormatFeatureFlags VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT = VkFormatFeatureFlags.SampledImageFilterLinear;
         public const VkFormatFeatureFlags VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG = VkFormatFeatureFlags.SampledImageFilterCubicImg;
+        public const VkFormatFeatureFlags VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR = VkFormatFeatureFlags.TransferSrc;
+        public const VkFormatFeatureFlags VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR = VkFormatFeatureFlags.TransferDst;
+        public const VkFormatFeatureFlags VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT = VkFormatFeatureFlags.SampledImageFilterMinmax;
     }
 
     [Flags]
@@ -2047,11 +2509,15 @@ namespace Vulkan
         None = 0,
         ///<summary>Dependency is per pixel region </summary>
         ByRegion = 1,
+        ViewLocalKhx = 2,
+        DeviceGroupKhx = 4,
     }
     public static partial class RawConstants
     {
         ///<summary>Dependency is per pixel region </summary>
         public const VkDependencyFlags VK_DEPENDENCY_BY_REGION_BIT = VkDependencyFlags.ByRegion;
+        public const VkDependencyFlags VK_DEPENDENCY_VIEW_LOCAL_BIT_KHX = VkDependencyFlags.ViewLocalKhx;
+        public const VkDependencyFlags VK_DEPENDENCY_DEVICE_GROUP_BIT_KHX = VkDependencyFlags.DeviceGroupKhx;
     }
 
     public enum VkPresentModeKHR
@@ -2060,6 +2526,8 @@ namespace Vulkan
         Mailbox = 1,
         Fifo = 2,
         FifoRelaxed = 3,
+        SharedDemandRefresh = 1000111000,
+        SharedContinuousRefresh = 1000111001,
     }
     public static partial class RawConstants
     {
@@ -2067,15 +2535,45 @@ namespace Vulkan
         public const VkPresentModeKHR VK_PRESENT_MODE_MAILBOX_KHR = VkPresentModeKHR.Mailbox;
         public const VkPresentModeKHR VK_PRESENT_MODE_FIFO_KHR = VkPresentModeKHR.Fifo;
         public const VkPresentModeKHR VK_PRESENT_MODE_FIFO_RELAXED_KHR = VkPresentModeKHR.FifoRelaxed;
+        public const VkPresentModeKHR VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR = VkPresentModeKHR.SharedDemandRefresh;
+        public const VkPresentModeKHR VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR = VkPresentModeKHR.SharedContinuousRefresh;
     }
 
     public enum VkColorSpaceKHR
     {
         SrgbNonlinear = 0,
+        DisplayP3Nonlinear = 1000104001,
+        ExtendedSrgbLinear = 1000104002,
+        DciP3Linear = 1000104003,
+        DciP3Nonlinear = 1000104004,
+        Bt709Linear = 1000104005,
+        Bt709Nonlinear = 1000104006,
+        Bt2020Linear = 1000104007,
+        Hdr10St2084 = 1000104008,
+        Dolbyvision = 1000104009,
+        Hdr10Hlg = 1000104010,
+        AdobergbLinear = 1000104011,
+        AdobergbNonlinear = 1000104012,
+        PassThrough = 1000104013,
+        ExtendedSrgbNonlinear = 1000104014,
     }
     public static partial class RawConstants
     {
         public const VkColorSpaceKHR VK_COLOR_SPACE_SRGB_NONLINEAR_KHR = VkColorSpaceKHR.SrgbNonlinear;
+        public const VkColorSpaceKHR VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT = VkColorSpaceKHR.DisplayP3Nonlinear;
+        public const VkColorSpaceKHR VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT = VkColorSpaceKHR.ExtendedSrgbLinear;
+        public const VkColorSpaceKHR VK_COLOR_SPACE_DCI_P3_LINEAR_EXT = VkColorSpaceKHR.DciP3Linear;
+        public const VkColorSpaceKHR VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT = VkColorSpaceKHR.DciP3Nonlinear;
+        public const VkColorSpaceKHR VK_COLOR_SPACE_BT709_LINEAR_EXT = VkColorSpaceKHR.Bt709Linear;
+        public const VkColorSpaceKHR VK_COLOR_SPACE_BT709_NONLINEAR_EXT = VkColorSpaceKHR.Bt709Nonlinear;
+        public const VkColorSpaceKHR VK_COLOR_SPACE_BT2020_LINEAR_EXT = VkColorSpaceKHR.Bt2020Linear;
+        public const VkColorSpaceKHR VK_COLOR_SPACE_HDR10_ST2084_EXT = VkColorSpaceKHR.Hdr10St2084;
+        public const VkColorSpaceKHR VK_COLOR_SPACE_DOLBYVISION_EXT = VkColorSpaceKHR.Dolbyvision;
+        public const VkColorSpaceKHR VK_COLOR_SPACE_HDR10_HLG_EXT = VkColorSpaceKHR.Hdr10Hlg;
+        public const VkColorSpaceKHR VK_COLOR_SPACE_ADOBERGB_LINEAR_EXT = VkColorSpaceKHR.AdobergbLinear;
+        public const VkColorSpaceKHR VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT = VkColorSpaceKHR.AdobergbNonlinear;
+        public const VkColorSpaceKHR VK_COLOR_SPACE_PASS_THROUGH_EXT = VkColorSpaceKHR.PassThrough;
+        public const VkColorSpaceKHR VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT = VkColorSpaceKHR.ExtendedSrgbNonlinear;
     }
 
     [Flags]
@@ -2188,11 +2686,12 @@ namespace Vulkan
         CommandPool = 25,
         Surface = 26,
         Swapchain = 27,
-        DebugReport = 28,
+        DebugReportCallback = 28,
         Display = 29,
         DisplayMode = 30,
         ObjectTable = 31,
         IndirectCommandsLayout = 32,
+        DescriptorUpdateTemplate = 1000085000,
     }
     public static partial class RawConstants
     {
@@ -2224,22 +2723,12 @@ namespace Vulkan
         public const VkDebugReportObjectTypeEXT VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT = VkDebugReportObjectTypeEXT.CommandPool;
         public const VkDebugReportObjectTypeEXT VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT = VkDebugReportObjectTypeEXT.Surface;
         public const VkDebugReportObjectTypeEXT VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT = VkDebugReportObjectTypeEXT.Swapchain;
-        public const VkDebugReportObjectTypeEXT VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT = VkDebugReportObjectTypeEXT.DebugReport;
+        public const VkDebugReportObjectTypeEXT VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT = VkDebugReportObjectTypeEXT.DebugReportCallback;
         public const VkDebugReportObjectTypeEXT VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT = VkDebugReportObjectTypeEXT.Display;
         public const VkDebugReportObjectTypeEXT VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT = VkDebugReportObjectTypeEXT.DisplayMode;
         public const VkDebugReportObjectTypeEXT VK_DEBUG_REPORT_OBJECT_TYPE_OBJECT_TABLE_NVX_EXT = VkDebugReportObjectTypeEXT.ObjectTable;
         public const VkDebugReportObjectTypeEXT VK_DEBUG_REPORT_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NVX_EXT = VkDebugReportObjectTypeEXT.IndirectCommandsLayout;
-    }
-
-    public enum VkDebugReportErrorEXT
-    {
-        None = 0,
-        CallbackRef = 1,
-    }
-    public static partial class RawConstants
-    {
-        public const VkDebugReportErrorEXT VK_DEBUG_REPORT_ERROR_NONE_EXT = VkDebugReportErrorEXT.None;
-        public const VkDebugReportErrorEXT VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT = VkDebugReportErrorEXT.CallbackRef;
+        public const VkDebugReportObjectTypeEXT VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR_EXT = VkDebugReportObjectTypeEXT.DescriptorUpdateTemplate;
     }
 
     public enum VkRasterizationOrderAMD
@@ -2288,10 +2777,12 @@ namespace Vulkan
     public enum VkValidationCheckEXT
     {
         All = 0,
+        Shaders = 1,
     }
     public static partial class RawConstants
     {
         public const VkValidationCheckEXT VK_VALIDATION_CHECK_ALL_EXT = VkValidationCheckEXT.All;
+        public const VkValidationCheckEXT VK_VALIDATION_CHECK_SHADERS_EXT = VkValidationCheckEXT.Shaders;
     }
 
     [Flags]
@@ -2326,41 +2817,378 @@ namespace Vulkan
 
     public enum VkIndirectCommandsTokenTypeNVX
     {
-        Pipeline = 0,
-        DescriptorSet = 1,
-        IndexBuffer = 2,
-        VertexBuffer = 3,
-        PushConstant = 4,
-        DrawIndexed = 5,
-        Draw = 6,
-        Dispatch = 7,
+        TypePipeline = 0,
+        TypeDescriptorSet = 1,
+        TypeIndexBuffer = 2,
+        TypeVertexBuffer = 3,
+        TypePushConstant = 4,
+        TypeDrawIndexed = 5,
+        TypeDraw = 6,
+        TypeDispatch = 7,
     }
     public static partial class RawConstants
     {
-        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_PIPELINE_NVX = VkIndirectCommandsTokenTypeNVX.Pipeline;
-        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_DESCRIPTOR_SET_NVX = VkIndirectCommandsTokenTypeNVX.DescriptorSet;
-        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_INDEX_BUFFER_NVX = VkIndirectCommandsTokenTypeNVX.IndexBuffer;
-        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_VERTEX_BUFFER_NVX = VkIndirectCommandsTokenTypeNVX.VertexBuffer;
-        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_PUSH_CONSTANT_NVX = VkIndirectCommandsTokenTypeNVX.PushConstant;
-        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_DRAW_INDEXED_NVX = VkIndirectCommandsTokenTypeNVX.DrawIndexed;
-        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_DRAW_NVX = VkIndirectCommandsTokenTypeNVX.Draw;
-        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_DISPATCH_NVX = VkIndirectCommandsTokenTypeNVX.Dispatch;
+        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_TYPE_PIPELINE_NVX = VkIndirectCommandsTokenTypeNVX.TypePipeline;
+        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_TYPE_DESCRIPTOR_SET_NVX = VkIndirectCommandsTokenTypeNVX.TypeDescriptorSet;
+        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_TYPE_INDEX_BUFFER_NVX = VkIndirectCommandsTokenTypeNVX.TypeIndexBuffer;
+        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_TYPE_VERTEX_BUFFER_NVX = VkIndirectCommandsTokenTypeNVX.TypeVertexBuffer;
+        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_TYPE_PUSH_CONSTANT_NVX = VkIndirectCommandsTokenTypeNVX.TypePushConstant;
+        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_INDEXED_NVX = VkIndirectCommandsTokenTypeNVX.TypeDrawIndexed;
+        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_NVX = VkIndirectCommandsTokenTypeNVX.TypeDraw;
+        public const VkIndirectCommandsTokenTypeNVX VK_INDIRECT_COMMANDS_TOKEN_TYPE_DISPATCH_NVX = VkIndirectCommandsTokenTypeNVX.TypeDispatch;
     }
 
     public enum VkObjectEntryTypeNVX
     {
-        DescriptorSet = 0,
-        Pipeline = 1,
-        IndexBuffer = 2,
-        VertexBuffer = 3,
-        PushConstant = 4,
+        TypeDescriptorSet = 0,
+        TypePipeline = 1,
+        TypeIndexBuffer = 2,
+        TypeVertexBuffer = 3,
+        TypePushConstant = 4,
     }
     public static partial class RawConstants
     {
-        public const VkObjectEntryTypeNVX VK_OBJECT_ENTRY_DESCRIPTOR_SET_NVX = VkObjectEntryTypeNVX.DescriptorSet;
-        public const VkObjectEntryTypeNVX VK_OBJECT_ENTRY_PIPELINE_NVX = VkObjectEntryTypeNVX.Pipeline;
-        public const VkObjectEntryTypeNVX VK_OBJECT_ENTRY_INDEX_BUFFER_NVX = VkObjectEntryTypeNVX.IndexBuffer;
-        public const VkObjectEntryTypeNVX VK_OBJECT_ENTRY_VERTEX_BUFFER_NVX = VkObjectEntryTypeNVX.VertexBuffer;
-        public const VkObjectEntryTypeNVX VK_OBJECT_ENTRY_PUSH_CONSTANT_NVX = VkObjectEntryTypeNVX.PushConstant;
+        public const VkObjectEntryTypeNVX VK_OBJECT_ENTRY_TYPE_DESCRIPTOR_SET_NVX = VkObjectEntryTypeNVX.TypeDescriptorSet;
+        public const VkObjectEntryTypeNVX VK_OBJECT_ENTRY_TYPE_PIPELINE_NVX = VkObjectEntryTypeNVX.TypePipeline;
+        public const VkObjectEntryTypeNVX VK_OBJECT_ENTRY_TYPE_INDEX_BUFFER_NVX = VkObjectEntryTypeNVX.TypeIndexBuffer;
+        public const VkObjectEntryTypeNVX VK_OBJECT_ENTRY_TYPE_VERTEX_BUFFER_NVX = VkObjectEntryTypeNVX.TypeVertexBuffer;
+        public const VkObjectEntryTypeNVX VK_OBJECT_ENTRY_TYPE_PUSH_CONSTANT_NVX = VkObjectEntryTypeNVX.TypePushConstant;
+    }
+
+    [Flags]
+    public enum VkDescriptorSetLayoutCreateFlags
+    {
+        None = 0,
+        PushDescriptor = 1,
+    }
+    public static partial class RawConstants
+    {
+        public const VkDescriptorSetLayoutCreateFlags VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR = VkDescriptorSetLayoutCreateFlags.PushDescriptor;
+    }
+
+    [Flags]
+    public enum VkExternalMemoryHandleTypeFlagsKHR
+    {
+        None = 0,
+        OpaqueFd = 1,
+        OpaqueWin32 = 2,
+        OpaqueWin32Kmt = 4,
+        D3d11Texture = 8,
+        D3d11TextureKmt = 16,
+        D3d12Heap = 32,
+        D3d12Resource = 64,
+    }
+    public static partial class RawConstants
+    {
+        public const VkExternalMemoryHandleTypeFlagsKHR VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR = VkExternalMemoryHandleTypeFlagsKHR.OpaqueFd;
+        public const VkExternalMemoryHandleTypeFlagsKHR VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR = VkExternalMemoryHandleTypeFlagsKHR.OpaqueWin32;
+        public const VkExternalMemoryHandleTypeFlagsKHR VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_KHR = VkExternalMemoryHandleTypeFlagsKHR.OpaqueWin32Kmt;
+        public const VkExternalMemoryHandleTypeFlagsKHR VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT_KHR = VkExternalMemoryHandleTypeFlagsKHR.D3d11Texture;
+        public const VkExternalMemoryHandleTypeFlagsKHR VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT_BIT_KHR = VkExternalMemoryHandleTypeFlagsKHR.D3d11TextureKmt;
+        public const VkExternalMemoryHandleTypeFlagsKHR VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP_BIT_KHR = VkExternalMemoryHandleTypeFlagsKHR.D3d12Heap;
+        public const VkExternalMemoryHandleTypeFlagsKHR VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE_BIT_KHR = VkExternalMemoryHandleTypeFlagsKHR.D3d12Resource;
+    }
+
+    [Flags]
+    public enum VkExternalMemoryFeatureFlagsKHR
+    {
+        None = 0,
+        DedicatedOnly = 1,
+        Exportable = 2,
+        Importable = 4,
+    }
+    public static partial class RawConstants
+    {
+        public const VkExternalMemoryFeatureFlagsKHR VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT_KHR = VkExternalMemoryFeatureFlagsKHR.DedicatedOnly;
+        public const VkExternalMemoryFeatureFlagsKHR VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT_KHR = VkExternalMemoryFeatureFlagsKHR.Exportable;
+        public const VkExternalMemoryFeatureFlagsKHR VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT_KHR = VkExternalMemoryFeatureFlagsKHR.Importable;
+    }
+
+    [Flags]
+    public enum VkExternalSemaphoreHandleTypeFlagsKHR
+    {
+        None = 0,
+        OpaqueFd = 1,
+        OpaqueWin32 = 2,
+        OpaqueWin32Kmt = 4,
+        D3d12Fence = 8,
+        SyncFd = 16,
+    }
+    public static partial class RawConstants
+    {
+        public const VkExternalSemaphoreHandleTypeFlagsKHR VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT_KHR = VkExternalSemaphoreHandleTypeFlagsKHR.OpaqueFd;
+        public const VkExternalSemaphoreHandleTypeFlagsKHR VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR = VkExternalSemaphoreHandleTypeFlagsKHR.OpaqueWin32;
+        public const VkExternalSemaphoreHandleTypeFlagsKHR VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_KHR = VkExternalSemaphoreHandleTypeFlagsKHR.OpaqueWin32Kmt;
+        public const VkExternalSemaphoreHandleTypeFlagsKHR VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT_KHR = VkExternalSemaphoreHandleTypeFlagsKHR.D3d12Fence;
+        public const VkExternalSemaphoreHandleTypeFlagsKHR VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT_KHR = VkExternalSemaphoreHandleTypeFlagsKHR.SyncFd;
+    }
+
+    [Flags]
+    public enum VkExternalSemaphoreFeatureFlagsKHR
+    {
+        None = 0,
+        Exportable = 1,
+        Importable = 2,
+    }
+    public static partial class RawConstants
+    {
+        public const VkExternalSemaphoreFeatureFlagsKHR VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR = VkExternalSemaphoreFeatureFlagsKHR.Exportable;
+        public const VkExternalSemaphoreFeatureFlagsKHR VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT_KHR = VkExternalSemaphoreFeatureFlagsKHR.Importable;
+    }
+
+    [Flags]
+    public enum VkSemaphoreImportFlagsKHR
+    {
+        None = 0,
+        Temporary = 1,
+    }
+    public static partial class RawConstants
+    {
+        public const VkSemaphoreImportFlagsKHR VK_SEMAPHORE_IMPORT_TEMPORARY_BIT_KHR = VkSemaphoreImportFlagsKHR.Temporary;
+    }
+
+    [Flags]
+    public enum VkExternalFenceHandleTypeFlagsKHR
+    {
+        None = 0,
+        OpaqueFd = 1,
+        OpaqueWin32 = 2,
+        OpaqueWin32Kmt = 4,
+        SyncFd = 8,
+    }
+    public static partial class RawConstants
+    {
+        public const VkExternalFenceHandleTypeFlagsKHR VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT_KHR = VkExternalFenceHandleTypeFlagsKHR.OpaqueFd;
+        public const VkExternalFenceHandleTypeFlagsKHR VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR = VkExternalFenceHandleTypeFlagsKHR.OpaqueWin32;
+        public const VkExternalFenceHandleTypeFlagsKHR VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_KHR = VkExternalFenceHandleTypeFlagsKHR.OpaqueWin32Kmt;
+        public const VkExternalFenceHandleTypeFlagsKHR VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT_KHR = VkExternalFenceHandleTypeFlagsKHR.SyncFd;
+    }
+
+    [Flags]
+    public enum VkExternalFenceFeatureFlagsKHR
+    {
+        None = 0,
+        Exportable = 1,
+        Importable = 2,
+    }
+    public static partial class RawConstants
+    {
+        public const VkExternalFenceFeatureFlagsKHR VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR = VkExternalFenceFeatureFlagsKHR.Exportable;
+        public const VkExternalFenceFeatureFlagsKHR VK_EXTERNAL_FENCE_FEATURE_IMPORTABLE_BIT_KHR = VkExternalFenceFeatureFlagsKHR.Importable;
+    }
+
+    [Flags]
+    public enum VkFenceImportFlagsKHR
+    {
+        None = 0,
+        Temporary = 1,
+    }
+    public static partial class RawConstants
+    {
+        public const VkFenceImportFlagsKHR VK_FENCE_IMPORT_TEMPORARY_BIT_KHR = VkFenceImportFlagsKHR.Temporary;
+    }
+
+    [Flags]
+    public enum VkSurfaceCounterFlagsEXT
+    {
+        None = 0,
+        Vblank = 1,
+    }
+    public static partial class RawConstants
+    {
+        public const VkSurfaceCounterFlagsEXT VK_SURFACE_COUNTER_VBLANK_EXT = VkSurfaceCounterFlagsEXT.Vblank;
+    }
+
+    public enum VkDisplayPowerStateEXT
+    {
+        Off = 0,
+        Suspend = 1,
+        On = 2,
+    }
+    public static partial class RawConstants
+    {
+        public const VkDisplayPowerStateEXT VK_DISPLAY_POWER_STATE_OFF_EXT = VkDisplayPowerStateEXT.Off;
+        public const VkDisplayPowerStateEXT VK_DISPLAY_POWER_STATE_SUSPEND_EXT = VkDisplayPowerStateEXT.Suspend;
+        public const VkDisplayPowerStateEXT VK_DISPLAY_POWER_STATE_ON_EXT = VkDisplayPowerStateEXT.On;
+    }
+
+    public enum VkDeviceEventTypeEXT
+    {
+        DisplayHotplug = 0,
+    }
+    public static partial class RawConstants
+    {
+        public const VkDeviceEventTypeEXT VK_DEVICE_EVENT_TYPE_DISPLAY_HOTPLUG_EXT = VkDeviceEventTypeEXT.DisplayHotplug;
+    }
+
+    public enum VkDisplayEventTypeEXT
+    {
+        FirstPixelOut = 0,
+    }
+    public static partial class RawConstants
+    {
+        public const VkDisplayEventTypeEXT VK_DISPLAY_EVENT_TYPE_FIRST_PIXEL_OUT_EXT = VkDisplayEventTypeEXT.FirstPixelOut;
+    }
+
+    [Flags]
+    public enum VkPeerMemoryFeatureFlagsKHX
+    {
+        None = 0,
+        ///<summary>Can read with vkCmdCopy commands</summary>
+        CopySrcKhx = 1,
+        ///<summary>Can write with vkCmdCopy commands</summary>
+        CopyDstKhx = 2,
+        ///<summary>Can read with any access type/command</summary>
+        GenericSrcKhx = 4,
+        ///<summary>Can write with and access type/command</summary>
+        GenericDstKhx = 8,
+    }
+    public static partial class RawConstants
+    {
+        ///<summary>Can read with vkCmdCopy commands</summary>
+        public const VkPeerMemoryFeatureFlagsKHX VK_PEER_MEMORY_FEATURE_COPY_SRC_BIT_KHX = VkPeerMemoryFeatureFlagsKHX.CopySrcKhx;
+        ///<summary>Can write with vkCmdCopy commands</summary>
+        public const VkPeerMemoryFeatureFlagsKHX VK_PEER_MEMORY_FEATURE_COPY_DST_BIT_KHX = VkPeerMemoryFeatureFlagsKHX.CopyDstKhx;
+        ///<summary>Can read with any access type/command</summary>
+        public const VkPeerMemoryFeatureFlagsKHX VK_PEER_MEMORY_FEATURE_GENERIC_SRC_BIT_KHX = VkPeerMemoryFeatureFlagsKHX.GenericSrcKhx;
+        ///<summary>Can write with and access type/command</summary>
+        public const VkPeerMemoryFeatureFlagsKHX VK_PEER_MEMORY_FEATURE_GENERIC_DST_BIT_KHX = VkPeerMemoryFeatureFlagsKHX.GenericDstKhx;
+    }
+
+    [Flags]
+    public enum VkMemoryAllocateFlagsKHX
+    {
+        None = 0,
+        ///<summary>Force allocation on specific devices</summary>
+        DeviceMaskKhx = 1,
+    }
+    public static partial class RawConstants
+    {
+        ///<summary>Force allocation on specific devices</summary>
+        public const VkMemoryAllocateFlagsKHX VK_MEMORY_ALLOCATE_DEVICE_MASK_BIT_KHX = VkMemoryAllocateFlagsKHX.DeviceMaskKhx;
+    }
+
+    [Flags]
+    public enum VkDeviceGroupPresentModeFlagsKHX
+    {
+        None = 0,
+        ///<summary>Present from local memory</summary>
+        LocalKhx = 1,
+        ///<summary>Present from remote memory</summary>
+        RemoteKhx = 2,
+        ///<summary>Present sum of local and/or remote memory</summary>
+        SumKhx = 4,
+        ///<summary>Each physical device presents from local memory</summary>
+        LocalMultiDeviceKhx = 8,
+    }
+    public static partial class RawConstants
+    {
+        ///<summary>Present from local memory</summary>
+        public const VkDeviceGroupPresentModeFlagsKHX VK_DEVICE_GROUP_PRESENT_MODE_LOCAL_BIT_KHX = VkDeviceGroupPresentModeFlagsKHX.LocalKhx;
+        ///<summary>Present from remote memory</summary>
+        public const VkDeviceGroupPresentModeFlagsKHX VK_DEVICE_GROUP_PRESENT_MODE_REMOTE_BIT_KHX = VkDeviceGroupPresentModeFlagsKHX.RemoteKhx;
+        ///<summary>Present sum of local and/or remote memory</summary>
+        public const VkDeviceGroupPresentModeFlagsKHX VK_DEVICE_GROUP_PRESENT_MODE_SUM_BIT_KHX = VkDeviceGroupPresentModeFlagsKHX.SumKhx;
+        ///<summary>Each physical device presents from local memory</summary>
+        public const VkDeviceGroupPresentModeFlagsKHX VK_DEVICE_GROUP_PRESENT_MODE_LOCAL_MULTI_DEVICE_BIT_KHX = VkDeviceGroupPresentModeFlagsKHX.LocalMultiDeviceKhx;
+    }
+
+    [Flags]
+    public enum VkSwapchainCreateFlagsKHR
+    {
+        None = 0,
+        BindSfrKhx = 1,
+    }
+    public static partial class RawConstants
+    {
+        public const VkSwapchainCreateFlagsKHR VK_SWAPCHAIN_CREATE_BIND_SFR_BIT_KHX = VkSwapchainCreateFlagsKHR.BindSfrKhx;
+    }
+
+    public enum VkViewportCoordinateSwizzleNV
+    {
+        VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_X_NV = 0,
+        VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_X_NV = 1,
+        VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_Y_NV = 2,
+        VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_Y_NV = 3,
+        VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_Z_NV = 4,
+        VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_Z_NV = 5,
+        VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_W_NV = 6,
+        VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_W_NV = 7,
+    }
+    public static partial class RawConstants
+    {
+        public const VkViewportCoordinateSwizzleNV VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_X_NV = VkViewportCoordinateSwizzleNV.VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_X_NV;
+        public const VkViewportCoordinateSwizzleNV VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_X_NV = VkViewportCoordinateSwizzleNV.VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_X_NV;
+        public const VkViewportCoordinateSwizzleNV VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_Y_NV = VkViewportCoordinateSwizzleNV.VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_Y_NV;
+        public const VkViewportCoordinateSwizzleNV VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_Y_NV = VkViewportCoordinateSwizzleNV.VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_Y_NV;
+        public const VkViewportCoordinateSwizzleNV VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_Z_NV = VkViewportCoordinateSwizzleNV.VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_Z_NV;
+        public const VkViewportCoordinateSwizzleNV VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_Z_NV = VkViewportCoordinateSwizzleNV.VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_Z_NV;
+        public const VkViewportCoordinateSwizzleNV VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_W_NV = VkViewportCoordinateSwizzleNV.VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_W_NV;
+        public const VkViewportCoordinateSwizzleNV VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_W_NV = VkViewportCoordinateSwizzleNV.VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_W_NV;
+    }
+
+    public enum VkDiscardRectangleModeEXT
+    {
+        Inclusive = 0,
+        Exclusive = 1,
+    }
+    public static partial class RawConstants
+    {
+        public const VkDiscardRectangleModeEXT VK_DISCARD_RECTANGLE_MODE_INCLUSIVE_EXT = VkDiscardRectangleModeEXT.Inclusive;
+        public const VkDiscardRectangleModeEXT VK_DISCARD_RECTANGLE_MODE_EXCLUSIVE_EXT = VkDiscardRectangleModeEXT.Exclusive;
+    }
+
+    [Flags]
+    public enum VkSubpassDescriptionFlags
+    {
+        None = 0,
+        PerViewAttributes = 1,
+        PerViewPositionXOnly = 2,
+    }
+    public static partial class RawConstants
+    {
+        public const VkSubpassDescriptionFlags VK_SUBPASS_DESCRIPTION_PER_VIEW_ATTRIBUTES_BIT_NVX = VkSubpassDescriptionFlags.PerViewAttributes;
+        public const VkSubpassDescriptionFlags VK_SUBPASS_DESCRIPTION_PER_VIEW_POSITION_X_ONLY_BIT_NVX = VkSubpassDescriptionFlags.PerViewPositionXOnly;
+    }
+
+    public enum VkSamplerReductionModeEXT
+    {
+        WeightedAverage = 0,
+        Min = 1,
+        Max = 2,
+    }
+    public static partial class RawConstants
+    {
+        public const VkSamplerReductionModeEXT VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE_EXT = VkSamplerReductionModeEXT.WeightedAverage;
+        public const VkSamplerReductionModeEXT VK_SAMPLER_REDUCTION_MODE_MIN_EXT = VkSamplerReductionModeEXT.Min;
+        public const VkSamplerReductionModeEXT VK_SAMPLER_REDUCTION_MODE_MAX_EXT = VkSamplerReductionModeEXT.Max;
+    }
+
+    public enum VkBlendOverlapEXT
+    {
+        Uncorrelated = 0,
+        Disjoint = 1,
+        Conjoint = 2,
+    }
+    public static partial class RawConstants
+    {
+        public const VkBlendOverlapEXT VK_BLEND_OVERLAP_UNCORRELATED_EXT = VkBlendOverlapEXT.Uncorrelated;
+        public const VkBlendOverlapEXT VK_BLEND_OVERLAP_DISJOINT_EXT = VkBlendOverlapEXT.Disjoint;
+        public const VkBlendOverlapEXT VK_BLEND_OVERLAP_CONJOINT_EXT = VkBlendOverlapEXT.Conjoint;
+    }
+
+    public enum VkCoverageModulationModeNV
+    {
+        VK_COVERAGE_MODULATION_MODE_NONE_NV = 0,
+        VK_COVERAGE_MODULATION_MODE_RGB_NV = 1,
+        VK_COVERAGE_MODULATION_MODE_ALPHA_NV = 2,
+        VK_COVERAGE_MODULATION_MODE_RGBA_NV = 3,
+    }
+    public static partial class RawConstants
+    {
+        public const VkCoverageModulationModeNV VK_COVERAGE_MODULATION_MODE_NONE_NV = VkCoverageModulationModeNV.VK_COVERAGE_MODULATION_MODE_NONE_NV;
+        public const VkCoverageModulationModeNV VK_COVERAGE_MODULATION_MODE_RGB_NV = VkCoverageModulationModeNV.VK_COVERAGE_MODULATION_MODE_RGB_NV;
+        public const VkCoverageModulationModeNV VK_COVERAGE_MODULATION_MODE_ALPHA_NV = VkCoverageModulationModeNV.VK_COVERAGE_MODULATION_MODE_ALPHA_NV;
+        public const VkCoverageModulationModeNV VK_COVERAGE_MODULATION_MODE_RGBA_NV = VkCoverageModulationModeNV.VK_COVERAGE_MODULATION_MODE_RGBA_NV;
     }
 }

--- a/src/vk/Generated/Handles.gen.cs
+++ b/src/vk/Generated/Handles.gen.cs
@@ -490,6 +490,24 @@ namespace Vulkan
         private string DebuggerDisplay => string.Format("VkIndirectCommandsLayoutNVX [{0}]", Handle);
     }
 
+    ///<summary>A non-dispatchable handle owned by a VkDevice.</summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public partial struct VkDescriptorUpdateTemplateKHR : IEquatable<VkDescriptorUpdateTemplateKHR>
+    {
+        public readonly IntPtr Handle;
+        public VkDescriptorUpdateTemplateKHR(IntPtr existingHandle) { Handle = existingHandle; }
+        public static VkDescriptorUpdateTemplateKHR Null => new VkDescriptorUpdateTemplateKHR(IntPtr.Zero);
+        public static implicit operator VkDescriptorUpdateTemplateKHR(IntPtr handle) => new VkDescriptorUpdateTemplateKHR(handle);
+        public static bool operator ==(VkDescriptorUpdateTemplateKHR left, VkDescriptorUpdateTemplateKHR right) => left.Handle == right.Handle;
+        public static bool operator !=(VkDescriptorUpdateTemplateKHR left, VkDescriptorUpdateTemplateKHR right) => left.Handle != right.Handle;
+        public static bool operator ==(VkDescriptorUpdateTemplateKHR left, IntPtr right) => left.Handle == right;
+        public static bool operator !=(VkDescriptorUpdateTemplateKHR left, IntPtr right) => left.Handle != right;
+        public bool Equals(VkDescriptorUpdateTemplateKHR h) => Handle.Equals(h.Handle);
+        public override bool Equals(object o) => o is VkDescriptorUpdateTemplateKHR h && Equals(h);
+        public override int GetHashCode() => Handle.GetHashCode();
+        private string DebuggerDisplay => string.Format("VkDescriptorUpdateTemplateKHR [{0}]", Handle);
+    }
+
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public partial struct VkDisplayKHR : IEquatable<VkDisplayKHR>
     {

--- a/src/vk/Generated/Structures.gen.cs
+++ b/src/vk/Generated/Structures.gen.cs
@@ -669,7 +669,7 @@ namespace Vulkan
     {
         public VkStructureType sType;
         public void* pNext;
-        public uint flags;
+        public VkDescriptorSetLayoutCreateFlags flags;
         public uint bindingCount;
         public VkDescriptorSetLayoutBinding* pBindings;
         public static VkDescriptorSetLayoutCreateInfo New()
@@ -1175,7 +1175,7 @@ namespace Vulkan
 
     public unsafe partial struct VkSubpassDescription
     {
-        public uint flags;
+        public VkSubpassDescriptionFlags flags;
         public VkPipelineBindPoint pipelineBindPoint;
         public uint inputAttachmentCount;
         public VkAttachmentReference* pInputAttachments;
@@ -1654,6 +1654,20 @@ namespace Vulkan
         }
     }
 
+    public unsafe partial struct VkViSurfaceCreateInfoNN
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint flags;
+        public void* window;
+        public static VkViSurfaceCreateInfoNN New()
+        {
+            VkViSurfaceCreateInfoNN ret = new VkViSurfaceCreateInfoNN();
+            ret.sType = VkStructureType.ViSurfaceCreateInfoNn;
+            return ret;
+        }
+    }
+
     public unsafe partial struct VkWaylandSurfaceCreateInfoKHR
     {
         public VkStructureType sType;
@@ -1724,7 +1738,7 @@ namespace Vulkan
     {
         public VkStructureType sType;
         public void* pNext;
-        public uint flags;
+        public VkSwapchainCreateFlagsKHR flags;
         public VkSurfaceKHR surface;
         public uint minImageCount;
         public VkFormat imageFormat;
@@ -1787,6 +1801,12 @@ namespace Vulkan
         public void* pNext;
         public uint disabledValidationCheckCount;
         public VkValidationCheckEXT* pDisabledValidationChecks;
+        public static VkValidationFlagsEXT New()
+        {
+            VkValidationFlagsEXT ret = new VkValidationFlagsEXT();
+            ret.sType = VkStructureType.Validation;
+            return ret;
+        }
     }
 
     public unsafe partial struct VkPipelineRasterizationStateRasterizationOrderAMD
@@ -1907,7 +1927,7 @@ namespace Vulkan
         public static VkExternalMemoryImageCreateInfoNV New()
         {
             VkExternalMemoryImageCreateInfoNV ret = new VkExternalMemoryImageCreateInfoNV();
-            ret.sType = VkStructureType.ExternalMemoryImageCreateInfo;
+            ret.sType = VkStructureType.ExportMemoryImageCreateInfoNV;
             return ret;
         }
     }
@@ -1920,7 +1940,7 @@ namespace Vulkan
         public static VkExportMemoryAllocateInfoNV New()
         {
             VkExportMemoryAllocateInfoNV ret = new VkExportMemoryAllocateInfoNV();
-            ret.sType = VkStructureType.ExportMemoryAllocateInfo;
+            ret.sType = VkStructureType.ExportMemoryAllocateInfoNV;
             return ret;
         }
     }
@@ -1934,7 +1954,7 @@ namespace Vulkan
         public static VkImportMemoryWin32HandleInfoNV New()
         {
             VkImportMemoryWin32HandleInfoNV ret = new VkImportMemoryWin32HandleInfoNV();
-            ret.sType = VkStructureType.ImportMemoryWin32HandleInfo;
+            ret.sType = VkStructureType.ImportMemoryWin32HandleInfoNV;
             return ret;
         }
     }
@@ -1948,7 +1968,7 @@ namespace Vulkan
         public static VkExportMemoryWin32HandleInfoNV New()
         {
             VkExportMemoryWin32HandleInfoNV ret = new VkExportMemoryWin32HandleInfoNV();
-            ret.sType = VkStructureType.ExportMemoryWin32HandleInfo;
+            ret.sType = VkStructureType.ExportMemoryWin32HandleInfoNV;
             return ret;
         }
     }
@@ -1967,7 +1987,7 @@ namespace Vulkan
         public static VkWin32KeyedMutexAcquireReleaseInfoNV New()
         {
             VkWin32KeyedMutexAcquireReleaseInfoNV ret = new VkWin32KeyedMutexAcquireReleaseInfoNV();
-            ret.sType = VkStructureType.Win32KeyedMutexAcquireReleaseInfo;
+            ret.sType = VkStructureType.Win32KeyedMutexAcquireReleaseInfoNV;
             return ret;
         }
     }
@@ -2124,6 +2144,7 @@ namespace Vulkan
         public VkObjectEntryTypeNVX type;
         public VkObjectEntryUsageFlagsNVX flags;
         public VkBuffer buffer;
+        public VkIndexType indexType;
     }
 
     public unsafe partial struct VkObjectTablePushConstantEntryNVX
@@ -2132,5 +2153,1529 @@ namespace Vulkan
         public VkObjectEntryUsageFlagsNVX flags;
         public VkPipelineLayout pipelineLayout;
         public VkShaderStageFlags stageFlags;
+    }
+
+    public unsafe partial struct VkPhysicalDeviceFeatures2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkPhysicalDeviceFeatures features;
+        public static VkPhysicalDeviceFeatures2KHR New()
+        {
+            VkPhysicalDeviceFeatures2KHR ret = new VkPhysicalDeviceFeatures2KHR();
+            ret.sType = VkStructureType.PhysicalDeviceFeatures2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceProperties2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkPhysicalDeviceProperties properties;
+        public static VkPhysicalDeviceProperties2KHR New()
+        {
+            VkPhysicalDeviceProperties2KHR ret = new VkPhysicalDeviceProperties2KHR();
+            ret.sType = VkStructureType.PhysicalDeviceProperties2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkFormatProperties2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkFormatProperties formatProperties;
+        public static VkFormatProperties2KHR New()
+        {
+            VkFormatProperties2KHR ret = new VkFormatProperties2KHR();
+            ret.sType = VkStructureType.FormatProperties2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkImageFormatProperties2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkImageFormatProperties imageFormatProperties;
+        public static VkImageFormatProperties2KHR New()
+        {
+            VkImageFormatProperties2KHR ret = new VkImageFormatProperties2KHR();
+            ret.sType = VkStructureType.ImageFormatProperties2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceImageFormatInfo2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkFormat format;
+        public VkImageType type;
+        public VkImageTiling tiling;
+        public VkImageUsageFlags usage;
+        public VkImageCreateFlags flags;
+        public static VkPhysicalDeviceImageFormatInfo2KHR New()
+        {
+            VkPhysicalDeviceImageFormatInfo2KHR ret = new VkPhysicalDeviceImageFormatInfo2KHR();
+            ret.sType = VkStructureType.PhysicalDeviceImageFormatInfo2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkQueueFamilyProperties2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkQueueFamilyProperties queueFamilyProperties;
+        public static VkQueueFamilyProperties2KHR New()
+        {
+            VkQueueFamilyProperties2KHR ret = new VkQueueFamilyProperties2KHR();
+            ret.sType = VkStructureType.QueueFamilyProperties2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceMemoryProperties2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkPhysicalDeviceMemoryProperties memoryProperties;
+        public static VkPhysicalDeviceMemoryProperties2KHR New()
+        {
+            VkPhysicalDeviceMemoryProperties2KHR ret = new VkPhysicalDeviceMemoryProperties2KHR();
+            ret.sType = VkStructureType.PhysicalDeviceMemoryProperties2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkSparseImageFormatProperties2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkSparseImageFormatProperties properties;
+        public static VkSparseImageFormatProperties2KHR New()
+        {
+            VkSparseImageFormatProperties2KHR ret = new VkSparseImageFormatProperties2KHR();
+            ret.sType = VkStructureType.SparseImageFormatProperties2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceSparseImageFormatInfo2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkFormat format;
+        public VkImageType type;
+        public VkSampleCountFlags samples;
+        public VkImageUsageFlags usage;
+        public VkImageTiling tiling;
+        public static VkPhysicalDeviceSparseImageFormatInfo2KHR New()
+        {
+            VkPhysicalDeviceSparseImageFormatInfo2KHR ret = new VkPhysicalDeviceSparseImageFormatInfo2KHR();
+            ret.sType = VkStructureType.PhysicalDeviceSparseImageFormatInfo2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDevicePushDescriptorPropertiesKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint maxPushDescriptors;
+        public static VkPhysicalDevicePushDescriptorPropertiesKHR New()
+        {
+            VkPhysicalDevicePushDescriptorPropertiesKHR ret = new VkPhysicalDevicePushDescriptorPropertiesKHR();
+            ret.sType = VkStructureType.PhysicalDevicePushDescriptorProperties;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPresentRegionsKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint swapchainCount;
+        public VkPresentRegionKHR* pRegions;
+        public static VkPresentRegionsKHR New()
+        {
+            VkPresentRegionsKHR ret = new VkPresentRegionsKHR();
+            ret.sType = VkStructureType.PresentRegions;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPresentRegionKHR
+    {
+        public uint rectangleCount;
+        public VkRectLayerKHR* pRectangles;
+    }
+
+    public unsafe partial struct VkRectLayerKHR
+    {
+        public VkOffset2D offset;
+        public VkExtent2D extent;
+        public uint layer;
+    }
+
+    public unsafe partial struct VkPhysicalDeviceVariablePointerFeaturesKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkBool32 variablePointersStorageBuffer;
+        public VkBool32 variablePointers;
+        public static VkPhysicalDeviceVariablePointerFeaturesKHR New()
+        {
+            VkPhysicalDeviceVariablePointerFeaturesKHR ret = new VkPhysicalDeviceVariablePointerFeaturesKHR();
+            ret.sType = VkStructureType.PhysicalDeviceVariablePointerFeatures;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkExternalMemoryPropertiesKHR
+    {
+        public VkExternalMemoryFeatureFlagsKHR externalMemoryFeatures;
+        public VkExternalMemoryHandleTypeFlagsKHR exportFromImportedHandleTypes;
+        public VkExternalMemoryHandleTypeFlagsKHR compatibleHandleTypes;
+    }
+
+    public unsafe partial struct VkPhysicalDeviceExternalImageFormatInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkExternalMemoryHandleTypeFlagsKHR handleType;
+        public static VkPhysicalDeviceExternalImageFormatInfoKHR New()
+        {
+            VkPhysicalDeviceExternalImageFormatInfoKHR ret = new VkPhysicalDeviceExternalImageFormatInfoKHR();
+            ret.sType = VkStructureType.PhysicalDeviceExternalImageFormatInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkExternalImageFormatPropertiesKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkExternalMemoryPropertiesKHR externalMemoryProperties;
+        public static VkExternalImageFormatPropertiesKHR New()
+        {
+            VkExternalImageFormatPropertiesKHR ret = new VkExternalImageFormatPropertiesKHR();
+            ret.sType = VkStructureType.ExternalImageFormatProperties;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceExternalBufferInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkBufferCreateFlags flags;
+        public VkBufferUsageFlags usage;
+        public VkExternalMemoryHandleTypeFlagsKHR handleType;
+        public static VkPhysicalDeviceExternalBufferInfoKHR New()
+        {
+            VkPhysicalDeviceExternalBufferInfoKHR ret = new VkPhysicalDeviceExternalBufferInfoKHR();
+            ret.sType = VkStructureType.PhysicalDeviceExternalBufferInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkExternalBufferPropertiesKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkExternalMemoryPropertiesKHR externalMemoryProperties;
+        public static VkExternalBufferPropertiesKHR New()
+        {
+            VkExternalBufferPropertiesKHR ret = new VkExternalBufferPropertiesKHR();
+            ret.sType = VkStructureType.ExternalBufferProperties;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceIDPropertiesKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public fixed byte deviceUUID[(int)VulkanNative.UuidSize];
+        public fixed byte driverUUID[(int)VulkanNative.UuidSize];
+        public fixed byte deviceLUID[(int)VulkanNative.LuidSize];
+        public uint deviceNodeMask;
+        public VkBool32 deviceLUIDValid;
+        public static VkPhysicalDeviceIDPropertiesKHR New()
+        {
+            VkPhysicalDeviceIDPropertiesKHR ret = new VkPhysicalDeviceIDPropertiesKHR();
+            ret.sType = VkStructureType.PhysicalDeviceIdProperties;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkExternalMemoryImageCreateInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkExternalMemoryHandleTypeFlagsKHR handleTypes;
+        public static VkExternalMemoryImageCreateInfoKHR New()
+        {
+            VkExternalMemoryImageCreateInfoKHR ret = new VkExternalMemoryImageCreateInfoKHR();
+            ret.sType = VkStructureType.ExportMemoryImageCreateInfoKHR;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkExternalMemoryBufferCreateInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkExternalMemoryHandleTypeFlagsKHR handleTypes;
+        public static VkExternalMemoryBufferCreateInfoKHR New()
+        {
+            VkExternalMemoryBufferCreateInfoKHR ret = new VkExternalMemoryBufferCreateInfoKHR();
+            ret.sType = VkStructureType.ExternalMemoryBufferCreateInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkExportMemoryAllocateInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkExternalMemoryHandleTypeFlagsKHR handleTypes;
+        public static VkExportMemoryAllocateInfoKHR New()
+        {
+            VkExportMemoryAllocateInfoKHR ret = new VkExportMemoryAllocateInfoKHR();
+            ret.sType = VkStructureType.ExportMemoryAllocateInfoKHR;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkImportMemoryWin32HandleInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkExternalMemoryHandleTypeFlagsKHR handleType;
+        public Win32.HANDLE handle;
+        public IntPtr name;
+        public static VkImportMemoryWin32HandleInfoKHR New()
+        {
+            VkImportMemoryWin32HandleInfoKHR ret = new VkImportMemoryWin32HandleInfoKHR();
+            ret.sType = VkStructureType.ImportMemoryWin32HandleInfoKHR;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkExportMemoryWin32HandleInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public Win32.SECURITY_ATTRIBUTES* pAttributes;
+        public uint dwAccess;
+        public IntPtr name;
+        public static VkExportMemoryWin32HandleInfoKHR New()
+        {
+            VkExportMemoryWin32HandleInfoKHR ret = new VkExportMemoryWin32HandleInfoKHR();
+            ret.sType = VkStructureType.ExportMemoryWin32HandleInfoKHR;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkMemoryWin32HandlePropertiesKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint memoryTypeBits;
+        public static VkMemoryWin32HandlePropertiesKHR New()
+        {
+            VkMemoryWin32HandlePropertiesKHR ret = new VkMemoryWin32HandlePropertiesKHR();
+            ret.sType = VkStructureType.MemoryWin32HandleProperties;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkMemoryGetWin32HandleInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkDeviceMemory memory;
+        public VkExternalMemoryHandleTypeFlagsKHR handleType;
+        public static VkMemoryGetWin32HandleInfoKHR New()
+        {
+            VkMemoryGetWin32HandleInfoKHR ret = new VkMemoryGetWin32HandleInfoKHR();
+            ret.sType = VkStructureType.MemoryGetWin32HandleInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkImportMemoryFdInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkExternalMemoryHandleTypeFlagsKHR handleType;
+        public int fd;
+        public static VkImportMemoryFdInfoKHR New()
+        {
+            VkImportMemoryFdInfoKHR ret = new VkImportMemoryFdInfoKHR();
+            ret.sType = VkStructureType.ImportMemoryFdInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkMemoryFdPropertiesKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint memoryTypeBits;
+        public static VkMemoryFdPropertiesKHR New()
+        {
+            VkMemoryFdPropertiesKHR ret = new VkMemoryFdPropertiesKHR();
+            ret.sType = VkStructureType.MemoryFdProperties;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkMemoryGetFdInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkDeviceMemory memory;
+        public VkExternalMemoryHandleTypeFlagsKHR handleType;
+        public static VkMemoryGetFdInfoKHR New()
+        {
+            VkMemoryGetFdInfoKHR ret = new VkMemoryGetFdInfoKHR();
+            ret.sType = VkStructureType.MemoryGetFdInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkWin32KeyedMutexAcquireReleaseInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint acquireCount;
+        public VkDeviceMemory* pAcquireSyncs;
+        public ulong* pAcquireKeys;
+        public uint* pAcquireTimeouts;
+        public uint releaseCount;
+        public VkDeviceMemory* pReleaseSyncs;
+        public ulong* pReleaseKeys;
+        public static VkWin32KeyedMutexAcquireReleaseInfoKHR New()
+        {
+            VkWin32KeyedMutexAcquireReleaseInfoKHR ret = new VkWin32KeyedMutexAcquireReleaseInfoKHR();
+            ret.sType = VkStructureType.Win32KeyedMutexAcquireReleaseInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceExternalSemaphoreInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkExternalSemaphoreHandleTypeFlagsKHR handleType;
+        public static VkPhysicalDeviceExternalSemaphoreInfoKHR New()
+        {
+            VkPhysicalDeviceExternalSemaphoreInfoKHR ret = new VkPhysicalDeviceExternalSemaphoreInfoKHR();
+            ret.sType = VkStructureType.PhysicalDeviceExternalSemaphoreInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkExternalSemaphorePropertiesKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkExternalSemaphoreHandleTypeFlagsKHR exportFromImportedHandleTypes;
+        public VkExternalSemaphoreHandleTypeFlagsKHR compatibleHandleTypes;
+        public VkExternalSemaphoreFeatureFlagsKHR externalSemaphoreFeatures;
+        public static VkExternalSemaphorePropertiesKHR New()
+        {
+            VkExternalSemaphorePropertiesKHR ret = new VkExternalSemaphorePropertiesKHR();
+            ret.sType = VkStructureType.ExternalSemaphoreProperties;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkExportSemaphoreCreateInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkExternalSemaphoreHandleTypeFlagsKHR handleTypes;
+        public static VkExportSemaphoreCreateInfoKHR New()
+        {
+            VkExportSemaphoreCreateInfoKHR ret = new VkExportSemaphoreCreateInfoKHR();
+            ret.sType = VkStructureType.ExportSemaphoreCreateInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkImportSemaphoreWin32HandleInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkSemaphore semaphore;
+        public VkSemaphoreImportFlagsKHR flags;
+        public VkExternalSemaphoreHandleTypeFlagsKHR handleType;
+        public Win32.HANDLE handle;
+        public IntPtr name;
+        public static VkImportSemaphoreWin32HandleInfoKHR New()
+        {
+            VkImportSemaphoreWin32HandleInfoKHR ret = new VkImportSemaphoreWin32HandleInfoKHR();
+            ret.sType = VkStructureType.ImportSemaphoreWin32HandleInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkExportSemaphoreWin32HandleInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public Win32.SECURITY_ATTRIBUTES* pAttributes;
+        public uint dwAccess;
+        public IntPtr name;
+        public static VkExportSemaphoreWin32HandleInfoKHR New()
+        {
+            VkExportSemaphoreWin32HandleInfoKHR ret = new VkExportSemaphoreWin32HandleInfoKHR();
+            ret.sType = VkStructureType.ExportSemaphoreWin32HandleInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkD3D12FenceSubmitInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint waitSemaphoreValuesCount;
+        public ulong* pWaitSemaphoreValues;
+        public uint signalSemaphoreValuesCount;
+        public ulong* pSignalSemaphoreValues;
+        public static VkD3D12FenceSubmitInfoKHR New()
+        {
+            VkD3D12FenceSubmitInfoKHR ret = new VkD3D12FenceSubmitInfoKHR();
+            ret.sType = VkStructureType.D3d12FenceSubmitInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkSemaphoreGetWin32HandleInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkSemaphore semaphore;
+        public VkExternalSemaphoreHandleTypeFlagsKHR handleType;
+        public static VkSemaphoreGetWin32HandleInfoKHR New()
+        {
+            VkSemaphoreGetWin32HandleInfoKHR ret = new VkSemaphoreGetWin32HandleInfoKHR();
+            ret.sType = VkStructureType.SemaphoreGetWin32HandleInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkImportSemaphoreFdInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkSemaphore semaphore;
+        public VkSemaphoreImportFlagsKHR flags;
+        public VkExternalSemaphoreHandleTypeFlagsKHR handleType;
+        public int fd;
+        public static VkImportSemaphoreFdInfoKHR New()
+        {
+            VkImportSemaphoreFdInfoKHR ret = new VkImportSemaphoreFdInfoKHR();
+            ret.sType = VkStructureType.ImportSemaphoreFdInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkSemaphoreGetFdInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkSemaphore semaphore;
+        public VkExternalSemaphoreHandleTypeFlagsKHR handleType;
+        public static VkSemaphoreGetFdInfoKHR New()
+        {
+            VkSemaphoreGetFdInfoKHR ret = new VkSemaphoreGetFdInfoKHR();
+            ret.sType = VkStructureType.SemaphoreGetFdInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceExternalFenceInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkExternalFenceHandleTypeFlagsKHR handleType;
+        public static VkPhysicalDeviceExternalFenceInfoKHR New()
+        {
+            VkPhysicalDeviceExternalFenceInfoKHR ret = new VkPhysicalDeviceExternalFenceInfoKHR();
+            ret.sType = VkStructureType.PhysicalDeviceExternalFenceInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkExternalFencePropertiesKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkExternalFenceHandleTypeFlagsKHR exportFromImportedHandleTypes;
+        public VkExternalFenceHandleTypeFlagsKHR compatibleHandleTypes;
+        public VkExternalFenceFeatureFlagsKHR externalFenceFeatures;
+        public static VkExternalFencePropertiesKHR New()
+        {
+            VkExternalFencePropertiesKHR ret = new VkExternalFencePropertiesKHR();
+            ret.sType = VkStructureType.ExternalFenceProperties;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkExportFenceCreateInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkExternalFenceHandleTypeFlagsKHR handleTypes;
+        public static VkExportFenceCreateInfoKHR New()
+        {
+            VkExportFenceCreateInfoKHR ret = new VkExportFenceCreateInfoKHR();
+            ret.sType = VkStructureType.ExportFenceCreateInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkImportFenceWin32HandleInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkFence fence;
+        public VkFenceImportFlagsKHR flags;
+        public VkExternalFenceHandleTypeFlagsKHR handleType;
+        public Win32.HANDLE handle;
+        public IntPtr name;
+        public static VkImportFenceWin32HandleInfoKHR New()
+        {
+            VkImportFenceWin32HandleInfoKHR ret = new VkImportFenceWin32HandleInfoKHR();
+            ret.sType = VkStructureType.ImportFenceWin32HandleInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkExportFenceWin32HandleInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public Win32.SECURITY_ATTRIBUTES* pAttributes;
+        public uint dwAccess;
+        public IntPtr name;
+        public static VkExportFenceWin32HandleInfoKHR New()
+        {
+            VkExportFenceWin32HandleInfoKHR ret = new VkExportFenceWin32HandleInfoKHR();
+            ret.sType = VkStructureType.ExportFenceWin32HandleInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkFenceGetWin32HandleInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkFence fence;
+        public VkExternalFenceHandleTypeFlagsKHR handleType;
+        public static VkFenceGetWin32HandleInfoKHR New()
+        {
+            VkFenceGetWin32HandleInfoKHR ret = new VkFenceGetWin32HandleInfoKHR();
+            ret.sType = VkStructureType.FenceGetWin32HandleInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkImportFenceFdInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkFence fence;
+        public VkFenceImportFlagsKHR flags;
+        public VkExternalFenceHandleTypeFlagsKHR handleType;
+        public int fd;
+        public static VkImportFenceFdInfoKHR New()
+        {
+            VkImportFenceFdInfoKHR ret = new VkImportFenceFdInfoKHR();
+            ret.sType = VkStructureType.ImportFenceFdInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkFenceGetFdInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkFence fence;
+        public VkExternalFenceHandleTypeFlagsKHR handleType;
+        public static VkFenceGetFdInfoKHR New()
+        {
+            VkFenceGetFdInfoKHR ret = new VkFenceGetFdInfoKHR();
+            ret.sType = VkStructureType.FenceGetFdInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceMultiviewFeaturesKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkBool32 multiview;
+        public VkBool32 multiviewGeometryShader;
+        public VkBool32 multiviewTessellationShader;
+        public static VkPhysicalDeviceMultiviewFeaturesKHX New()
+        {
+            VkPhysicalDeviceMultiviewFeaturesKHX ret = new VkPhysicalDeviceMultiviewFeaturesKHX();
+            ret.sType = VkStructureType.PhysicalDeviceMultiviewFeaturesKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceMultiviewPropertiesKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint maxMultiviewViewCount;
+        public uint maxMultiviewInstanceIndex;
+        public static VkPhysicalDeviceMultiviewPropertiesKHX New()
+        {
+            VkPhysicalDeviceMultiviewPropertiesKHX ret = new VkPhysicalDeviceMultiviewPropertiesKHX();
+            ret.sType = VkStructureType.PhysicalDeviceMultiviewPropertiesKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkRenderPassMultiviewCreateInfoKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint subpassCount;
+        public uint* pViewMasks;
+        public uint dependencyCount;
+        public int* pViewOffsets;
+        public uint correlationMaskCount;
+        public uint* pCorrelationMasks;
+        public static VkRenderPassMultiviewCreateInfoKHX New()
+        {
+            VkRenderPassMultiviewCreateInfoKHX ret = new VkRenderPassMultiviewCreateInfoKHX();
+            ret.sType = VkStructureType.RenderPassMultiviewCreateInfoKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkSurfaceCapabilities2EXT
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint minImageCount;
+        public uint maxImageCount;
+        public VkExtent2D currentExtent;
+        public VkExtent2D minImageExtent;
+        public VkExtent2D maxImageExtent;
+        public uint maxImageArrayLayers;
+        public VkSurfaceTransformFlagsKHR supportedTransforms;
+        public VkSurfaceTransformFlagsKHR currentTransform;
+        public VkCompositeAlphaFlagsKHR supportedCompositeAlpha;
+        public VkImageUsageFlags supportedUsageFlags;
+        public VkSurfaceCounterFlagsEXT supportedSurfaceCounters;
+        public static VkSurfaceCapabilities2EXT New()
+        {
+            VkSurfaceCapabilities2EXT ret = new VkSurfaceCapabilities2EXT();
+            ret.sType = VkStructureType.SurfaceCapabilities2Ext;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkDisplayPowerInfoEXT
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkDisplayPowerStateEXT powerState;
+        public static VkDisplayPowerInfoEXT New()
+        {
+            VkDisplayPowerInfoEXT ret = new VkDisplayPowerInfoEXT();
+            ret.sType = VkStructureType.DisplayPowerInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkDeviceEventInfoEXT
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkDeviceEventTypeEXT deviceEvent;
+        public static VkDeviceEventInfoEXT New()
+        {
+            VkDeviceEventInfoEXT ret = new VkDeviceEventInfoEXT();
+            ret.sType = VkStructureType.DeviceEventInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkDisplayEventInfoEXT
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkDisplayEventTypeEXT displayEvent;
+        public static VkDisplayEventInfoEXT New()
+        {
+            VkDisplayEventInfoEXT ret = new VkDisplayEventInfoEXT();
+            ret.sType = VkStructureType.DisplayEventInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkSwapchainCounterCreateInfoEXT
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkSurfaceCounterFlagsEXT surfaceCounters;
+        public static VkSwapchainCounterCreateInfoEXT New()
+        {
+            VkSwapchainCounterCreateInfoEXT ret = new VkSwapchainCounterCreateInfoEXT();
+            ret.sType = VkStructureType.SwapchainCounterCreateInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceGroupPropertiesKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint physicalDeviceCount;
+        public VkPhysicalDevice physicalDevices_0;
+        public VkPhysicalDevice physicalDevices_1;
+        public VkPhysicalDevice physicalDevices_2;
+        public VkPhysicalDevice physicalDevices_3;
+        public VkPhysicalDevice physicalDevices_4;
+        public VkPhysicalDevice physicalDevices_5;
+        public VkPhysicalDevice physicalDevices_6;
+        public VkPhysicalDevice physicalDevices_7;
+        public VkPhysicalDevice physicalDevices_8;
+        public VkPhysicalDevice physicalDevices_9;
+        public VkPhysicalDevice physicalDevices_10;
+        public VkPhysicalDevice physicalDevices_11;
+        public VkPhysicalDevice physicalDevices_12;
+        public VkPhysicalDevice physicalDevices_13;
+        public VkPhysicalDevice physicalDevices_14;
+        public VkPhysicalDevice physicalDevices_15;
+        public VkPhysicalDevice physicalDevices_16;
+        public VkPhysicalDevice physicalDevices_17;
+        public VkPhysicalDevice physicalDevices_18;
+        public VkPhysicalDevice physicalDevices_19;
+        public VkPhysicalDevice physicalDevices_20;
+        public VkPhysicalDevice physicalDevices_21;
+        public VkPhysicalDevice physicalDevices_22;
+        public VkPhysicalDevice physicalDevices_23;
+        public VkPhysicalDevice physicalDevices_24;
+        public VkPhysicalDevice physicalDevices_25;
+        public VkPhysicalDevice physicalDevices_26;
+        public VkPhysicalDevice physicalDevices_27;
+        public VkPhysicalDevice physicalDevices_28;
+        public VkPhysicalDevice physicalDevices_29;
+        public VkPhysicalDevice physicalDevices_30;
+        public VkPhysicalDevice physicalDevices_31;
+        public VkBool32 subsetAllocation;
+        public static VkPhysicalDeviceGroupPropertiesKHX New()
+        {
+            VkPhysicalDeviceGroupPropertiesKHX ret = new VkPhysicalDeviceGroupPropertiesKHX();
+            ret.sType = VkStructureType.PhysicalDeviceGroupPropertiesKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkMemoryAllocateFlagsInfoKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkMemoryAllocateFlagsKHX flags;
+        public uint deviceMask;
+        public static VkMemoryAllocateFlagsInfoKHX New()
+        {
+            VkMemoryAllocateFlagsInfoKHX ret = new VkMemoryAllocateFlagsInfoKHX();
+            ret.sType = VkStructureType.MemoryAllocateInfoKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkBindBufferMemoryInfoKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkBuffer buffer;
+        public VkDeviceMemory memory;
+        public ulong memoryOffset;
+        public uint deviceIndexCount;
+        public uint* pDeviceIndices;
+        public static VkBindBufferMemoryInfoKHX New()
+        {
+            VkBindBufferMemoryInfoKHX ret = new VkBindBufferMemoryInfoKHX();
+            ret.sType = VkStructureType.BindBufferMemoryInfoKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkBindImageMemoryInfoKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkImage image;
+        public VkDeviceMemory memory;
+        public ulong memoryOffset;
+        public uint deviceIndexCount;
+        public uint* pDeviceIndices;
+        public uint SFRRectCount;
+        public VkRect2D* pSFRRects;
+        public static VkBindImageMemoryInfoKHX New()
+        {
+            VkBindImageMemoryInfoKHX ret = new VkBindImageMemoryInfoKHX();
+            ret.sType = VkStructureType.BindImageMemoryInfoKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkDeviceGroupRenderPassBeginInfoKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint deviceMask;
+        public uint deviceRenderAreaCount;
+        public VkRect2D* pDeviceRenderAreas;
+        public static VkDeviceGroupRenderPassBeginInfoKHX New()
+        {
+            VkDeviceGroupRenderPassBeginInfoKHX ret = new VkDeviceGroupRenderPassBeginInfoKHX();
+            ret.sType = VkStructureType.DeviceGroupRenderPassBeginInfoKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkDeviceGroupCommandBufferBeginInfoKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint deviceMask;
+        public static VkDeviceGroupCommandBufferBeginInfoKHX New()
+        {
+            VkDeviceGroupCommandBufferBeginInfoKHX ret = new VkDeviceGroupCommandBufferBeginInfoKHX();
+            ret.sType = VkStructureType.DeviceGroupCommandBufferBeginInfoKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkDeviceGroupSubmitInfoKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint waitSemaphoreCount;
+        public uint* pWaitSemaphoreDeviceIndices;
+        public uint commandBufferCount;
+        public uint* pCommandBufferDeviceMasks;
+        public uint signalSemaphoreCount;
+        public uint* pSignalSemaphoreDeviceIndices;
+        public static VkDeviceGroupSubmitInfoKHX New()
+        {
+            VkDeviceGroupSubmitInfoKHX ret = new VkDeviceGroupSubmitInfoKHX();
+            ret.sType = VkStructureType.DeviceGroupSubmitInfoKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkDeviceGroupBindSparseInfoKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint resourceDeviceIndex;
+        public uint memoryDeviceIndex;
+        public static VkDeviceGroupBindSparseInfoKHX New()
+        {
+            VkDeviceGroupBindSparseInfoKHX ret = new VkDeviceGroupBindSparseInfoKHX();
+            ret.sType = VkStructureType.DeviceGroupBindSparseInfoKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkDeviceGroupPresentCapabilitiesKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public fixed uint presentMask[(int)VulkanNative.MaxDeviceGroupSizeKhx];
+        public VkDeviceGroupPresentModeFlagsKHX modes;
+        public static VkDeviceGroupPresentCapabilitiesKHX New()
+        {
+            VkDeviceGroupPresentCapabilitiesKHX ret = new VkDeviceGroupPresentCapabilitiesKHX();
+            ret.sType = VkStructureType.DeviceGroupPresentCapabilitiesKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkImageSwapchainCreateInfoKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkSwapchainKHR swapchain;
+        public static VkImageSwapchainCreateInfoKHX New()
+        {
+            VkImageSwapchainCreateInfoKHX ret = new VkImageSwapchainCreateInfoKHX();
+            ret.sType = VkStructureType.ImageSwapchainCreateInfoKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkBindImageMemorySwapchainInfoKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkSwapchainKHR swapchain;
+        public uint imageIndex;
+        public static VkBindImageMemorySwapchainInfoKHX New()
+        {
+            VkBindImageMemorySwapchainInfoKHX ret = new VkBindImageMemorySwapchainInfoKHX();
+            ret.sType = VkStructureType.BindImageMemorySwapchainInfoKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkAcquireNextImageInfoKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkSwapchainKHR swapchain;
+        public ulong timeout;
+        public VkSemaphore semaphore;
+        public VkFence fence;
+        public uint deviceMask;
+        public static VkAcquireNextImageInfoKHX New()
+        {
+            VkAcquireNextImageInfoKHX ret = new VkAcquireNextImageInfoKHX();
+            ret.sType = VkStructureType.AcquireNextImageInfoKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkDeviceGroupPresentInfoKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint swapchainCount;
+        public uint* pDeviceMasks;
+        public VkDeviceGroupPresentModeFlagsKHX mode;
+        public static VkDeviceGroupPresentInfoKHX New()
+        {
+            VkDeviceGroupPresentInfoKHX ret = new VkDeviceGroupPresentInfoKHX();
+            ret.sType = VkStructureType.DeviceGroupPresentInfoKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkDeviceGroupDeviceCreateInfoKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint physicalDeviceCount;
+        public VkPhysicalDevice* pPhysicalDevices;
+        public static VkDeviceGroupDeviceCreateInfoKHX New()
+        {
+            VkDeviceGroupDeviceCreateInfoKHX ret = new VkDeviceGroupDeviceCreateInfoKHX();
+            ret.sType = VkStructureType.DeviceGroupDeviceCreateInfoKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkDeviceGroupSwapchainCreateInfoKHX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkDeviceGroupPresentModeFlagsKHX modes;
+        public static VkDeviceGroupSwapchainCreateInfoKHX New()
+        {
+            VkDeviceGroupSwapchainCreateInfoKHX ret = new VkDeviceGroupSwapchainCreateInfoKHX();
+            ret.sType = VkStructureType.DeviceGroupSwapchainCreateInfoKhx;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkDescriptorUpdateTemplateEntryKHR
+    {
+        public uint dstBinding;
+        public uint dstArrayElement;
+        public uint descriptorCount;
+        public VkDescriptorType descriptorType;
+        public UIntPtr offset;
+        public UIntPtr stride;
+    }
+
+    public unsafe partial struct VkDescriptorUpdateTemplateCreateInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint flags;
+        public uint descriptorUpdateEntryCount;
+        public VkDescriptorUpdateTemplateEntryKHR* pDescriptorUpdateEntries;
+        public VkDescriptorUpdateTemplateTypeKHR templateType;
+        public VkDescriptorSetLayout descriptorSetLayout;
+        public VkPipelineBindPoint pipelineBindPoint;
+        public VkPipelineLayout pipelineLayout;
+        public uint set;
+        public static VkDescriptorUpdateTemplateCreateInfoKHR New()
+        {
+            VkDescriptorUpdateTemplateCreateInfoKHR ret = new VkDescriptorUpdateTemplateCreateInfoKHR();
+            ret.sType = VkStructureType.DescriptorUpdateTemplateCreateInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkXYColorEXT
+    {
+        public float x;
+        public float y;
+    }
+
+    public unsafe partial struct VkHdrMetadataEXT
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkXYColorEXT displayPrimaryRed;
+        public VkXYColorEXT displayPrimaryGreen;
+        public VkXYColorEXT displayPrimaryBlue;
+        public VkXYColorEXT whitePoint;
+        public float maxLuminance;
+        public float minLuminance;
+        public float maxContentLightLevel;
+        public float maxFrameAverageLightLevel;
+        public static VkHdrMetadataEXT New()
+        {
+            VkHdrMetadataEXT ret = new VkHdrMetadataEXT();
+            ret.sType = VkStructureType.HdrMetadata;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkRefreshCycleDurationGOOGLE
+    {
+        public ulong refreshDuration;
+    }
+
+    public unsafe partial struct VkPastPresentationTimingGOOGLE
+    {
+        public uint presentID;
+        public ulong desiredPresentTime;
+        public ulong actualPresentTime;
+        public ulong earliestPresentTime;
+        public ulong presentMargin;
+    }
+
+    public unsafe partial struct VkPresentTimesInfoGOOGLE
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint swapchainCount;
+        public VkPresentTimeGOOGLE* pTimes;
+        public static VkPresentTimesInfoGOOGLE New()
+        {
+            VkPresentTimesInfoGOOGLE ret = new VkPresentTimesInfoGOOGLE();
+            ret.sType = VkStructureType.PresentTimesInfoGoogle;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPresentTimeGOOGLE
+    {
+        public uint presentID;
+        public ulong desiredPresentTime;
+    }
+
+    public unsafe partial struct VkIOSSurfaceCreateInfoMVK
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint flags;
+        public void* pView;
+        public static VkIOSSurfaceCreateInfoMVK New()
+        {
+            VkIOSSurfaceCreateInfoMVK ret = new VkIOSSurfaceCreateInfoMVK();
+            ret.sType = VkStructureType.IosSurfaceCreateInfoMvk;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkMacOSSurfaceCreateInfoMVK
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint flags;
+        public void* pView;
+        public static VkMacOSSurfaceCreateInfoMVK New()
+        {
+            VkMacOSSurfaceCreateInfoMVK ret = new VkMacOSSurfaceCreateInfoMVK();
+            ret.sType = VkStructureType.MacosSurfaceCreateInfoMvk;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkViewportWScalingNV
+    {
+        public float xcoeff;
+        public float ycoeff;
+    }
+
+    public unsafe partial struct VkPipelineViewportWScalingStateCreateInfoNV
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkBool32 viewportWScalingEnable;
+        public uint viewportCount;
+        public VkViewportWScalingNV* pViewportWScalings;
+        public static VkPipelineViewportWScalingStateCreateInfoNV New()
+        {
+            VkPipelineViewportWScalingStateCreateInfoNV ret = new VkPipelineViewportWScalingStateCreateInfoNV();
+            ret.sType = VkStructureType.PipelineViewportWScalingStateCreateInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkViewportSwizzleNV
+    {
+        public VkViewportCoordinateSwizzleNV x;
+        public VkViewportCoordinateSwizzleNV y;
+        public VkViewportCoordinateSwizzleNV z;
+        public VkViewportCoordinateSwizzleNV w;
+    }
+
+    public unsafe partial struct VkPipelineViewportSwizzleStateCreateInfoNV
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint flags;
+        public uint viewportCount;
+        public VkViewportSwizzleNV* pViewportSwizzles;
+        public static VkPipelineViewportSwizzleStateCreateInfoNV New()
+        {
+            VkPipelineViewportSwizzleStateCreateInfoNV ret = new VkPipelineViewportSwizzleStateCreateInfoNV();
+            ret.sType = VkStructureType.PipelineViewportSwizzleStateCreateInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceDiscardRectanglePropertiesEXT
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint maxDiscardRectangles;
+        public static VkPhysicalDeviceDiscardRectanglePropertiesEXT New()
+        {
+            VkPhysicalDeviceDiscardRectanglePropertiesEXT ret = new VkPhysicalDeviceDiscardRectanglePropertiesEXT();
+            ret.sType = VkStructureType.PhysicalDeviceDiscardRectangleProperties;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPipelineDiscardRectangleStateCreateInfoEXT
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint flags;
+        public VkDiscardRectangleModeEXT discardRectangleMode;
+        public uint discardRectangleCount;
+        public VkRect2D* pDiscardRectangles;
+        public static VkPipelineDiscardRectangleStateCreateInfoEXT New()
+        {
+            VkPipelineDiscardRectangleStateCreateInfoEXT ret = new VkPipelineDiscardRectangleStateCreateInfoEXT();
+            ret.sType = VkStructureType.PipelineDiscardRectangleStateCreateInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkBool32 perViewPositionAllComponents;
+        public static VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX New()
+        {
+            VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX ret = new VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX();
+            ret.sType = VkStructureType.PhysicalDeviceMultiviewPerViewAttributesProperties;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceSurfaceInfo2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkSurfaceKHR surface;
+        public static VkPhysicalDeviceSurfaceInfo2KHR New()
+        {
+            VkPhysicalDeviceSurfaceInfo2KHR ret = new VkPhysicalDeviceSurfaceInfo2KHR();
+            ret.sType = VkStructureType.PhysicalDeviceSurfaceInfo2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkSurfaceCapabilities2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkSurfaceCapabilitiesKHR surfaceCapabilities;
+        public static VkSurfaceCapabilities2KHR New()
+        {
+            VkSurfaceCapabilities2KHR ret = new VkSurfaceCapabilities2KHR();
+            ret.sType = VkStructureType.SurfaceCapabilities2Khr;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkSurfaceFormat2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkSurfaceFormatKHR surfaceFormat;
+        public static VkSurfaceFormat2KHR New()
+        {
+            VkSurfaceFormat2KHR ret = new VkSurfaceFormat2KHR();
+            ret.sType = VkStructureType.SurfaceFormat2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkSharedPresentSurfaceCapabilitiesKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkImageUsageFlags sharedPresentSupportedUsageFlags;
+        public static VkSharedPresentSurfaceCapabilitiesKHR New()
+        {
+            VkSharedPresentSurfaceCapabilitiesKHR ret = new VkSharedPresentSurfaceCapabilitiesKHR();
+            ret.sType = VkStructureType.SharedPresentSurfaceCapabilities;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDevice16BitStorageFeaturesKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkBool32 storageBuffer16BitAccess;
+        public VkBool32 uniformAndStorageBuffer16BitAccess;
+        public VkBool32 storagePushConstant16;
+        public VkBool32 storageInputOutput16;
+        public static VkPhysicalDevice16BitStorageFeaturesKHR New()
+        {
+            VkPhysicalDevice16BitStorageFeaturesKHR ret = new VkPhysicalDevice16BitStorageFeaturesKHR();
+            ret.sType = VkStructureType.PhysicalDevice16bitStorageFeatures;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkBufferMemoryRequirementsInfo2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkBuffer buffer;
+        public static VkBufferMemoryRequirementsInfo2KHR New()
+        {
+            VkBufferMemoryRequirementsInfo2KHR ret = new VkBufferMemoryRequirementsInfo2KHR();
+            ret.sType = VkStructureType.BufferMemoryRequirementsInfo2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkImageMemoryRequirementsInfo2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkImage image;
+        public static VkImageMemoryRequirementsInfo2KHR New()
+        {
+            VkImageMemoryRequirementsInfo2KHR ret = new VkImageMemoryRequirementsInfo2KHR();
+            ret.sType = VkStructureType.ImageMemoryRequirementsInfo2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkImageSparseMemoryRequirementsInfo2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkImage image;
+        public static VkImageSparseMemoryRequirementsInfo2KHR New()
+        {
+            VkImageSparseMemoryRequirementsInfo2KHR ret = new VkImageSparseMemoryRequirementsInfo2KHR();
+            ret.sType = VkStructureType.ImageSparseMemoryRequirementsInfo2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkMemoryRequirements2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkMemoryRequirements memoryRequirements;
+        public static VkMemoryRequirements2KHR New()
+        {
+            VkMemoryRequirements2KHR ret = new VkMemoryRequirements2KHR();
+            ret.sType = VkStructureType.MemoryRequirements2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkSparseImageMemoryRequirements2KHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkSparseImageMemoryRequirements memoryRequirements;
+        public static VkSparseImageMemoryRequirements2KHR New()
+        {
+            VkSparseImageMemoryRequirements2KHR ret = new VkSparseImageMemoryRequirements2KHR();
+            ret.sType = VkStructureType.SparseImageMemoryRequirements2;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkMemoryDedicatedRequirementsKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkBool32 prefersDedicatedAllocation;
+        public VkBool32 requiresDedicatedAllocation;
+        public static VkMemoryDedicatedRequirementsKHR New()
+        {
+            VkMemoryDedicatedRequirementsKHR ret = new VkMemoryDedicatedRequirementsKHR();
+            ret.sType = VkStructureType.MemoryDedicatedRequirements;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkMemoryDedicatedAllocateInfoKHR
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkImage image;
+        public VkBuffer buffer;
+        public static VkMemoryDedicatedAllocateInfoKHR New()
+        {
+            VkMemoryDedicatedAllocateInfoKHR ret = new VkMemoryDedicatedAllocateInfoKHR();
+            ret.sType = VkStructureType.MemoryDedicatedAllocateInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkTextureLODGatherFormatPropertiesAMD
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkBool32 supportsTextureGatherLODBiasAMD;
+        public static VkTextureLODGatherFormatPropertiesAMD New()
+        {
+            VkTextureLODGatherFormatPropertiesAMD ret = new VkTextureLODGatherFormatPropertiesAMD();
+            ret.sType = VkStructureType.TextureLodGatherFormatProperties;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPipelineCoverageToColorStateCreateInfoNV
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint flags;
+        public VkBool32 coverageToColorEnable;
+        public uint coverageToColorLocation;
+        public static VkPipelineCoverageToColorStateCreateInfoNV New()
+        {
+            VkPipelineCoverageToColorStateCreateInfoNV ret = new VkPipelineCoverageToColorStateCreateInfoNV();
+            ret.sType = VkStructureType.PipelineCoverageToColorStateCreateInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkBool32 filterMinmaxSingleComponentFormats;
+        public VkBool32 filterMinmaxImageComponentMapping;
+        public static VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT New()
+        {
+            VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT ret = new VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT();
+            ret.sType = VkStructureType.PhysicalDeviceSamplerFilterMinmaxProperties;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkSamplerReductionModeCreateInfoEXT
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkSamplerReductionModeEXT reductionMode;
+        public static VkSamplerReductionModeCreateInfoEXT New()
+        {
+            VkSamplerReductionModeCreateInfoEXT ret = new VkSamplerReductionModeCreateInfoEXT();
+            ret.sType = VkStructureType.SamplerReductionModeCreateInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkBool32 advancedBlendCoherentOperations;
+        public static VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT New()
+        {
+            VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT ret = new VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT();
+            ret.sType = VkStructureType.PhysicalDeviceBlendOperationAdvancedFeatures;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint advancedBlendMaxColorAttachments;
+        public VkBool32 advancedBlendIndependentBlend;
+        public VkBool32 advancedBlendNonPremultipliedSrcColor;
+        public VkBool32 advancedBlendNonPremultipliedDstColor;
+        public VkBool32 advancedBlendCorrelatedOverlap;
+        public VkBool32 advancedBlendAllOperations;
+        public static VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT New()
+        {
+            VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT ret = new VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT();
+            ret.sType = VkStructureType.PhysicalDeviceBlendOperationAdvancedProperties;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPipelineColorBlendAdvancedStateCreateInfoEXT
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public VkBool32 srcPremultiplied;
+        public VkBool32 dstPremultiplied;
+        public VkBlendOverlapEXT blendOverlap;
+        public static VkPipelineColorBlendAdvancedStateCreateInfoEXT New()
+        {
+            VkPipelineColorBlendAdvancedStateCreateInfoEXT ret = new VkPipelineColorBlendAdvancedStateCreateInfoEXT();
+            ret.sType = VkStructureType.PipelineColorBlendAdvancedStateCreateInfo;
+            return ret;
+        }
+    }
+
+    public unsafe partial struct VkPipelineCoverageModulationStateCreateInfoNV
+    {
+        public VkStructureType sType;
+        public void* pNext;
+        public uint flags;
+        public VkCoverageModulationModeNV coverageModulationMode;
+        public VkBool32 coverageModulationTableEnable;
+        public uint coverageModulationTableCount;
+        public float* pCoverageModulationTable;
+        public static VkPipelineCoverageModulationStateCreateInfoNV New()
+        {
+            VkPipelineCoverageModulationStateCreateInfoNV ret = new VkPipelineCoverageModulationStateCreateInfoNV();
+            ret.sType = VkStructureType.PipelineCoverageModulationStateCreateInfo;
+            return ret;
+        }
     }
 }


### PR DESCRIPTION
Update to vulkan 1.58 xml.
Map some collide NV, KHR, enum values from VkStructureType.
Maybe would be better to keep suffix like NV, Ext, KHR when mapping VkStructureType?

Related to issue #5 