### PR TITLE
Change codegen for handles to avoid IntPtr boxing in Equals

### DIFF
--- a/src/vk.generator/HandleHelpers.cs
+++ b/src/vk.generator/HandleHelpers.cs
@@ -29,7 +29,7 @@ namespace Vk.Generator
                 cw.WriteLine($"public static bool operator !=({handle.Name} left, {handle.Name} right) => left.Handle != right.Handle;");
                 cw.WriteLine($"public static bool operator ==({handle.Name} left, {handleType} right) => left.Handle == right;");
                 cw.WriteLine($"public static bool operator !=({handle.Name} left, {handleType} right) => left.Handle != right;");
-                cw.WriteLine($"public bool Equals({handle.Name} h) => Handle.Equals(h.Handle);");
+                cw.WriteLine($"public bool Equals({handle.Name} h) => Handle == h.Handle;");
                 cw.WriteLine($"public override bool Equals(object o) => o is {handle.Name} h && Equals(h);");
                 cw.WriteLine($"public override int GetHashCode() => Handle.GetHashCode();");
                 cw.WriteLine($"private string DebuggerDisplay => string.Format(\"{handle.Name} [0x{{0}}]\", Handle.ToString(\"X\"));");

--- a/src/vk/Generated/Handles.gen.cs
+++ b/src/vk/Generated/Handles.gen.cs
@@ -16,7 +16,7 @@ namespace Vulkan
         public static bool operator !=(VkInstance left, VkInstance right) => left.Handle != right.Handle;
         public static bool operator ==(VkInstance left, IntPtr right) => left.Handle == right;
         public static bool operator !=(VkInstance left, IntPtr right) => left.Handle != right;
-        public bool Equals(VkInstance h) => Handle.Equals(h.Handle);
+        public bool Equals(VkInstance h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkInstance h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkInstance [0x{0}]", Handle.ToString("X"));
@@ -34,7 +34,7 @@ namespace Vulkan
         public static bool operator !=(VkPhysicalDevice left, VkPhysicalDevice right) => left.Handle != right.Handle;
         public static bool operator ==(VkPhysicalDevice left, IntPtr right) => left.Handle == right;
         public static bool operator !=(VkPhysicalDevice left, IntPtr right) => left.Handle != right;
-        public bool Equals(VkPhysicalDevice h) => Handle.Equals(h.Handle);
+        public bool Equals(VkPhysicalDevice h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkPhysicalDevice h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkPhysicalDevice [0x{0}]", Handle.ToString("X"));
@@ -52,7 +52,7 @@ namespace Vulkan
         public static bool operator !=(VkDevice left, VkDevice right) => left.Handle != right.Handle;
         public static bool operator ==(VkDevice left, IntPtr right) => left.Handle == right;
         public static bool operator !=(VkDevice left, IntPtr right) => left.Handle != right;
-        public bool Equals(VkDevice h) => Handle.Equals(h.Handle);
+        public bool Equals(VkDevice h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkDevice h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkDevice [0x{0}]", Handle.ToString("X"));
@@ -70,7 +70,7 @@ namespace Vulkan
         public static bool operator !=(VkQueue left, VkQueue right) => left.Handle != right.Handle;
         public static bool operator ==(VkQueue left, IntPtr right) => left.Handle == right;
         public static bool operator !=(VkQueue left, IntPtr right) => left.Handle != right;
-        public bool Equals(VkQueue h) => Handle.Equals(h.Handle);
+        public bool Equals(VkQueue h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkQueue h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkQueue [0x{0}]", Handle.ToString("X"));
@@ -88,7 +88,7 @@ namespace Vulkan
         public static bool operator !=(VkCommandBuffer left, VkCommandBuffer right) => left.Handle != right.Handle;
         public static bool operator ==(VkCommandBuffer left, IntPtr right) => left.Handle == right;
         public static bool operator !=(VkCommandBuffer left, IntPtr right) => left.Handle != right;
-        public bool Equals(VkCommandBuffer h) => Handle.Equals(h.Handle);
+        public bool Equals(VkCommandBuffer h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkCommandBuffer h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkCommandBuffer [0x{0}]", Handle.ToString("X"));
@@ -106,7 +106,7 @@ namespace Vulkan
         public static bool operator !=(VkDeviceMemory left, VkDeviceMemory right) => left.Handle != right.Handle;
         public static bool operator ==(VkDeviceMemory left, ulong right) => left.Handle == right;
         public static bool operator !=(VkDeviceMemory left, ulong right) => left.Handle != right;
-        public bool Equals(VkDeviceMemory h) => Handle.Equals(h.Handle);
+        public bool Equals(VkDeviceMemory h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkDeviceMemory h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkDeviceMemory [0x{0}]", Handle.ToString("X"));
@@ -124,7 +124,7 @@ namespace Vulkan
         public static bool operator !=(VkCommandPool left, VkCommandPool right) => left.Handle != right.Handle;
         public static bool operator ==(VkCommandPool left, ulong right) => left.Handle == right;
         public static bool operator !=(VkCommandPool left, ulong right) => left.Handle != right;
-        public bool Equals(VkCommandPool h) => Handle.Equals(h.Handle);
+        public bool Equals(VkCommandPool h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkCommandPool h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkCommandPool [0x{0}]", Handle.ToString("X"));
@@ -142,7 +142,7 @@ namespace Vulkan
         public static bool operator !=(VkBuffer left, VkBuffer right) => left.Handle != right.Handle;
         public static bool operator ==(VkBuffer left, ulong right) => left.Handle == right;
         public static bool operator !=(VkBuffer left, ulong right) => left.Handle != right;
-        public bool Equals(VkBuffer h) => Handle.Equals(h.Handle);
+        public bool Equals(VkBuffer h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkBuffer h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkBuffer [0x{0}]", Handle.ToString("X"));
@@ -160,7 +160,7 @@ namespace Vulkan
         public static bool operator !=(VkBufferView left, VkBufferView right) => left.Handle != right.Handle;
         public static bool operator ==(VkBufferView left, ulong right) => left.Handle == right;
         public static bool operator !=(VkBufferView left, ulong right) => left.Handle != right;
-        public bool Equals(VkBufferView h) => Handle.Equals(h.Handle);
+        public bool Equals(VkBufferView h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkBufferView h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkBufferView [0x{0}]", Handle.ToString("X"));
@@ -178,7 +178,7 @@ namespace Vulkan
         public static bool operator !=(VkImage left, VkImage right) => left.Handle != right.Handle;
         public static bool operator ==(VkImage left, ulong right) => left.Handle == right;
         public static bool operator !=(VkImage left, ulong right) => left.Handle != right;
-        public bool Equals(VkImage h) => Handle.Equals(h.Handle);
+        public bool Equals(VkImage h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkImage h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkImage [0x{0}]", Handle.ToString("X"));
@@ -196,7 +196,7 @@ namespace Vulkan
         public static bool operator !=(VkImageView left, VkImageView right) => left.Handle != right.Handle;
         public static bool operator ==(VkImageView left, ulong right) => left.Handle == right;
         public static bool operator !=(VkImageView left, ulong right) => left.Handle != right;
-        public bool Equals(VkImageView h) => Handle.Equals(h.Handle);
+        public bool Equals(VkImageView h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkImageView h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkImageView [0x{0}]", Handle.ToString("X"));
@@ -214,7 +214,7 @@ namespace Vulkan
         public static bool operator !=(VkShaderModule left, VkShaderModule right) => left.Handle != right.Handle;
         public static bool operator ==(VkShaderModule left, ulong right) => left.Handle == right;
         public static bool operator !=(VkShaderModule left, ulong right) => left.Handle != right;
-        public bool Equals(VkShaderModule h) => Handle.Equals(h.Handle);
+        public bool Equals(VkShaderModule h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkShaderModule h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkShaderModule [0x{0}]", Handle.ToString("X"));
@@ -232,7 +232,7 @@ namespace Vulkan
         public static bool operator !=(VkPipeline left, VkPipeline right) => left.Handle != right.Handle;
         public static bool operator ==(VkPipeline left, ulong right) => left.Handle == right;
         public static bool operator !=(VkPipeline left, ulong right) => left.Handle != right;
-        public bool Equals(VkPipeline h) => Handle.Equals(h.Handle);
+        public bool Equals(VkPipeline h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkPipeline h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkPipeline [0x{0}]", Handle.ToString("X"));
@@ -250,7 +250,7 @@ namespace Vulkan
         public static bool operator !=(VkPipelineLayout left, VkPipelineLayout right) => left.Handle != right.Handle;
         public static bool operator ==(VkPipelineLayout left, ulong right) => left.Handle == right;
         public static bool operator !=(VkPipelineLayout left, ulong right) => left.Handle != right;
-        public bool Equals(VkPipelineLayout h) => Handle.Equals(h.Handle);
+        public bool Equals(VkPipelineLayout h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkPipelineLayout h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkPipelineLayout [0x{0}]", Handle.ToString("X"));
@@ -268,7 +268,7 @@ namespace Vulkan
         public static bool operator !=(VkSampler left, VkSampler right) => left.Handle != right.Handle;
         public static bool operator ==(VkSampler left, ulong right) => left.Handle == right;
         public static bool operator !=(VkSampler left, ulong right) => left.Handle != right;
-        public bool Equals(VkSampler h) => Handle.Equals(h.Handle);
+        public bool Equals(VkSampler h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkSampler h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkSampler [0x{0}]", Handle.ToString("X"));
@@ -286,7 +286,7 @@ namespace Vulkan
         public static bool operator !=(VkDescriptorSet left, VkDescriptorSet right) => left.Handle != right.Handle;
         public static bool operator ==(VkDescriptorSet left, ulong right) => left.Handle == right;
         public static bool operator !=(VkDescriptorSet left, ulong right) => left.Handle != right;
-        public bool Equals(VkDescriptorSet h) => Handle.Equals(h.Handle);
+        public bool Equals(VkDescriptorSet h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkDescriptorSet h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkDescriptorSet [0x{0}]", Handle.ToString("X"));
@@ -304,7 +304,7 @@ namespace Vulkan
         public static bool operator !=(VkDescriptorSetLayout left, VkDescriptorSetLayout right) => left.Handle != right.Handle;
         public static bool operator ==(VkDescriptorSetLayout left, ulong right) => left.Handle == right;
         public static bool operator !=(VkDescriptorSetLayout left, ulong right) => left.Handle != right;
-        public bool Equals(VkDescriptorSetLayout h) => Handle.Equals(h.Handle);
+        public bool Equals(VkDescriptorSetLayout h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkDescriptorSetLayout h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkDescriptorSetLayout [0x{0}]", Handle.ToString("X"));
@@ -322,7 +322,7 @@ namespace Vulkan
         public static bool operator !=(VkDescriptorPool left, VkDescriptorPool right) => left.Handle != right.Handle;
         public static bool operator ==(VkDescriptorPool left, ulong right) => left.Handle == right;
         public static bool operator !=(VkDescriptorPool left, ulong right) => left.Handle != right;
-        public bool Equals(VkDescriptorPool h) => Handle.Equals(h.Handle);
+        public bool Equals(VkDescriptorPool h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkDescriptorPool h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkDescriptorPool [0x{0}]", Handle.ToString("X"));
@@ -340,7 +340,7 @@ namespace Vulkan
         public static bool operator !=(VkFence left, VkFence right) => left.Handle != right.Handle;
         public static bool operator ==(VkFence left, ulong right) => left.Handle == right;
         public static bool operator !=(VkFence left, ulong right) => left.Handle != right;
-        public bool Equals(VkFence h) => Handle.Equals(h.Handle);
+        public bool Equals(VkFence h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkFence h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkFence [0x{0}]", Handle.ToString("X"));
@@ -358,7 +358,7 @@ namespace Vulkan
         public static bool operator !=(VkSemaphore left, VkSemaphore right) => left.Handle != right.Handle;
         public static bool operator ==(VkSemaphore left, ulong right) => left.Handle == right;
         public static bool operator !=(VkSemaphore left, ulong right) => left.Handle != right;
-        public bool Equals(VkSemaphore h) => Handle.Equals(h.Handle);
+        public bool Equals(VkSemaphore h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkSemaphore h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkSemaphore [0x{0}]", Handle.ToString("X"));
@@ -376,7 +376,7 @@ namespace Vulkan
         public static bool operator !=(VkEvent left, VkEvent right) => left.Handle != right.Handle;
         public static bool operator ==(VkEvent left, ulong right) => left.Handle == right;
         public static bool operator !=(VkEvent left, ulong right) => left.Handle != right;
-        public bool Equals(VkEvent h) => Handle.Equals(h.Handle);
+        public bool Equals(VkEvent h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkEvent h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkEvent [0x{0}]", Handle.ToString("X"));
@@ -394,7 +394,7 @@ namespace Vulkan
         public static bool operator !=(VkQueryPool left, VkQueryPool right) => left.Handle != right.Handle;
         public static bool operator ==(VkQueryPool left, ulong right) => left.Handle == right;
         public static bool operator !=(VkQueryPool left, ulong right) => left.Handle != right;
-        public bool Equals(VkQueryPool h) => Handle.Equals(h.Handle);
+        public bool Equals(VkQueryPool h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkQueryPool h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkQueryPool [0x{0}]", Handle.ToString("X"));
@@ -412,7 +412,7 @@ namespace Vulkan
         public static bool operator !=(VkFramebuffer left, VkFramebuffer right) => left.Handle != right.Handle;
         public static bool operator ==(VkFramebuffer left, ulong right) => left.Handle == right;
         public static bool operator !=(VkFramebuffer left, ulong right) => left.Handle != right;
-        public bool Equals(VkFramebuffer h) => Handle.Equals(h.Handle);
+        public bool Equals(VkFramebuffer h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkFramebuffer h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkFramebuffer [0x{0}]", Handle.ToString("X"));
@@ -430,7 +430,7 @@ namespace Vulkan
         public static bool operator !=(VkRenderPass left, VkRenderPass right) => left.Handle != right.Handle;
         public static bool operator ==(VkRenderPass left, ulong right) => left.Handle == right;
         public static bool operator !=(VkRenderPass left, ulong right) => left.Handle != right;
-        public bool Equals(VkRenderPass h) => Handle.Equals(h.Handle);
+        public bool Equals(VkRenderPass h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkRenderPass h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkRenderPass [0x{0}]", Handle.ToString("X"));
@@ -448,7 +448,7 @@ namespace Vulkan
         public static bool operator !=(VkPipelineCache left, VkPipelineCache right) => left.Handle != right.Handle;
         public static bool operator ==(VkPipelineCache left, ulong right) => left.Handle == right;
         public static bool operator !=(VkPipelineCache left, ulong right) => left.Handle != right;
-        public bool Equals(VkPipelineCache h) => Handle.Equals(h.Handle);
+        public bool Equals(VkPipelineCache h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkPipelineCache h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkPipelineCache [0x{0}]", Handle.ToString("X"));
@@ -466,7 +466,7 @@ namespace Vulkan
         public static bool operator !=(VkObjectTableNVX left, VkObjectTableNVX right) => left.Handle != right.Handle;
         public static bool operator ==(VkObjectTableNVX left, ulong right) => left.Handle == right;
         public static bool operator !=(VkObjectTableNVX left, ulong right) => left.Handle != right;
-        public bool Equals(VkObjectTableNVX h) => Handle.Equals(h.Handle);
+        public bool Equals(VkObjectTableNVX h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkObjectTableNVX h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkObjectTableNVX [0x{0}]", Handle.ToString("X"));
@@ -484,7 +484,7 @@ namespace Vulkan
         public static bool operator !=(VkIndirectCommandsLayoutNVX left, VkIndirectCommandsLayoutNVX right) => left.Handle != right.Handle;
         public static bool operator ==(VkIndirectCommandsLayoutNVX left, ulong right) => left.Handle == right;
         public static bool operator !=(VkIndirectCommandsLayoutNVX left, ulong right) => left.Handle != right;
-        public bool Equals(VkIndirectCommandsLayoutNVX h) => Handle.Equals(h.Handle);
+        public bool Equals(VkIndirectCommandsLayoutNVX h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkIndirectCommandsLayoutNVX h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkIndirectCommandsLayoutNVX [0x{0}]", Handle.ToString("X"));
@@ -502,7 +502,7 @@ namespace Vulkan
         public static bool operator !=(VkDescriptorUpdateTemplateKHR left, VkDescriptorUpdateTemplateKHR right) => left.Handle != right.Handle;
         public static bool operator ==(VkDescriptorUpdateTemplateKHR left, ulong right) => left.Handle == right;
         public static bool operator !=(VkDescriptorUpdateTemplateKHR left, ulong right) => left.Handle != right;
-        public bool Equals(VkDescriptorUpdateTemplateKHR h) => Handle.Equals(h.Handle);
+        public bool Equals(VkDescriptorUpdateTemplateKHR h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkDescriptorUpdateTemplateKHR h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkDescriptorUpdateTemplateKHR [0x{0}]", Handle.ToString("X"));
@@ -520,7 +520,7 @@ namespace Vulkan
         public static bool operator !=(VkSamplerYcbcrConversionKHR left, VkSamplerYcbcrConversionKHR right) => left.Handle != right.Handle;
         public static bool operator ==(VkSamplerYcbcrConversionKHR left, ulong right) => left.Handle == right;
         public static bool operator !=(VkSamplerYcbcrConversionKHR left, ulong right) => left.Handle != right;
-        public bool Equals(VkSamplerYcbcrConversionKHR h) => Handle.Equals(h.Handle);
+        public bool Equals(VkSamplerYcbcrConversionKHR h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkSamplerYcbcrConversionKHR h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkSamplerYcbcrConversionKHR [0x{0}]", Handle.ToString("X"));
@@ -538,7 +538,7 @@ namespace Vulkan
         public static bool operator !=(VkValidationCacheEXT left, VkValidationCacheEXT right) => left.Handle != right.Handle;
         public static bool operator ==(VkValidationCacheEXT left, ulong right) => left.Handle == right;
         public static bool operator !=(VkValidationCacheEXT left, ulong right) => left.Handle != right;
-        public bool Equals(VkValidationCacheEXT h) => Handle.Equals(h.Handle);
+        public bool Equals(VkValidationCacheEXT h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkValidationCacheEXT h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkValidationCacheEXT [0x{0}]", Handle.ToString("X"));
@@ -555,7 +555,7 @@ namespace Vulkan
         public static bool operator !=(VkDisplayKHR left, VkDisplayKHR right) => left.Handle != right.Handle;
         public static bool operator ==(VkDisplayKHR left, ulong right) => left.Handle == right;
         public static bool operator !=(VkDisplayKHR left, ulong right) => left.Handle != right;
-        public bool Equals(VkDisplayKHR h) => Handle.Equals(h.Handle);
+        public bool Equals(VkDisplayKHR h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkDisplayKHR h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkDisplayKHR [0x{0}]", Handle.ToString("X"));
@@ -573,7 +573,7 @@ namespace Vulkan
         public static bool operator !=(VkDisplayModeKHR left, VkDisplayModeKHR right) => left.Handle != right.Handle;
         public static bool operator ==(VkDisplayModeKHR left, ulong right) => left.Handle == right;
         public static bool operator !=(VkDisplayModeKHR left, ulong right) => left.Handle != right;
-        public bool Equals(VkDisplayModeKHR h) => Handle.Equals(h.Handle);
+        public bool Equals(VkDisplayModeKHR h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkDisplayModeKHR h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkDisplayModeKHR [0x{0}]", Handle.ToString("X"));
@@ -591,7 +591,7 @@ namespace Vulkan
         public static bool operator !=(VkSurfaceKHR left, VkSurfaceKHR right) => left.Handle != right.Handle;
         public static bool operator ==(VkSurfaceKHR left, ulong right) => left.Handle == right;
         public static bool operator !=(VkSurfaceKHR left, ulong right) => left.Handle != right;
-        public bool Equals(VkSurfaceKHR h) => Handle.Equals(h.Handle);
+        public bool Equals(VkSurfaceKHR h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkSurfaceKHR h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkSurfaceKHR [0x{0}]", Handle.ToString("X"));
@@ -609,7 +609,7 @@ namespace Vulkan
         public static bool operator !=(VkSwapchainKHR left, VkSwapchainKHR right) => left.Handle != right.Handle;
         public static bool operator ==(VkSwapchainKHR left, ulong right) => left.Handle == right;
         public static bool operator !=(VkSwapchainKHR left, ulong right) => left.Handle != right;
-        public bool Equals(VkSwapchainKHR h) => Handle.Equals(h.Handle);
+        public bool Equals(VkSwapchainKHR h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkSwapchainKHR h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkSwapchainKHR [0x{0}]", Handle.ToString("X"));
@@ -627,7 +627,7 @@ namespace Vulkan
         public static bool operator !=(VkDebugReportCallbackEXT left, VkDebugReportCallbackEXT right) => left.Handle != right.Handle;
         public static bool operator ==(VkDebugReportCallbackEXT left, ulong right) => left.Handle == right;
         public static bool operator !=(VkDebugReportCallbackEXT left, ulong right) => left.Handle != right;
-        public bool Equals(VkDebugReportCallbackEXT h) => Handle.Equals(h.Handle);
+        public bool Equals(VkDebugReportCallbackEXT h) => Handle == h.Handle;
         public override bool Equals(object o) => o is VkDebugReportCallbackEXT h && Equals(h);
         public override int GetHashCode() => Handle.GetHashCode();
         private string DebuggerDisplay => string.Format("VkDebugReportCallbackEXT [0x{0}]", Handle.ToString("X"));


### PR DESCRIPTION
IntPtr does not implement ``IEquatable<IntPtr>``. The equality operator should be used instead when comparing handles to avoid boxing allocations.