### PR TITLE
Link to libc instead of libdl on desktop linux

### DIFF
--- a/src/vk/Libc.cs
+++ b/src/vk/Libc.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Vulkan
+{
+    internal static class Libc
+    {
+        [DllImport("libc")]
+        public static extern IntPtr dlopen(string fileName, int flags);
+
+        [DllImport("libc")]
+        public static extern IntPtr dlsym(IntPtr handle, string name);
+
+        [DllImport("libc")]
+        public static extern int dlclose(IntPtr handle);
+
+        [DllImport("libc")]
+        public static extern string dlerror();
+
+        public const int RTLD_NOW = 0x002;
+    }
+}


### PR DESCRIPTION
As of glibc v2.34 it is preferred to link against libc.so instead of libdl.so. 

"In order to support smoother in-place-upgrades and to simplify
  the implementation of the runtime all functionality formerly
  implemented in the libraries libpthread, libdl, libutil, libanl has
  been integrated into libc"
(src: https://sourceware.org/pipermail/libc-alpha/2021-August/129718.html).

Some distributions don't provide a libdl.so symlink any more which is causing issues.

Ideally merge #40 before this to fix the build as well.

Related issues:
https://github.com/mellinoe/veldrid/issues/143
https://github.com/ppy/osu/issues/22956
